### PR TITLE
Collect offsets for EMPTY groups

### DIFF
--- a/minion/consumer_group_offsets.go
+++ b/minion/consumer_group_offsets.go
@@ -24,7 +24,7 @@ func (s *Service) ListAllConsumerGroupOffsetsAdminAPI(ctx context.Context) (map[
 	}
 	groupIDs := make([]string, len(groupsRes.AllowedGroups.Groups))
 	for i, group := range groupsRes.AllowedGroups.Groups {
-		if group.GroupState != "Empty" && group.GroupState != "Dead" {
+		if group.GroupState != "Dead" {
 			groupIDs[i] = group.Group
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR removes filtering for EMPTY consumer groups.

## Motivation and Context
Kafka consumers using `consumer.assign()` method for consuming will be reported as empty consumer groups. We also need to continue reporting offsets when all members of the consumer group left(due to restarts, connectivity issues or any other event). 

## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
