### PR TITLE
Expose max timestamp for each topic and/or partition

### DIFF
--- a/prometheus/collect_topic_partition_offsets.go
+++ b/prometheus/collect_topic_partition_offsets.go
@@ -25,6 +25,15 @@ func (e *Exporter) collectTopicPartitionOffsets(ctx context.Context, ch chan<- p
 		return false
 	}
 
+	// Highest Timestamp Offsets
+	// NB: this requires Kafka Brokers 3.0+ (see https://issues.apache.org/jira/browse/KAFKA-12541)
+	// In older versions this is returning the timestamp of the low watermarks (earliest offset)
+	maxTimestampOffsets, err := e.minionSvc.ListOffsetsCached(ctx, -3)
+	if err != nil {
+		e.logger.Warn("failed to fetch offsets for max timestamp", zap.Error(err))
+		return false
+	}
+
 	// Process Low Watermarks
 	for _, topic := range lowWaterMarks.Topics {
 		if !e.minionSvc.IsTopicAllowed(topic.Topic) {
@@ -101,5 +110,47 @@ func (e *Exporter) collectTopicPartitionOffsets(ctx context.Context, ch chan<- p
 		}
 	}
 
+	// Process Max Timestamps
+	for _, topic := range maxTimestampOffsets.Topics {
+		if !e.minionSvc.IsTopicAllowed(topic.Topic) {
+			continue
+		}
+		topicMaxTimestamp := int64(0)
+		hasErrors := false
+		for _, partition := range topic.Partitions {
+			err := kerr.ErrorForCode(partition.ErrorCode)
+			if err != nil {
+				hasErrors = true
+				isOk = false
+				continue
+			}
+			if topicMaxTimestamp < partition.Timestamp {
+				topicMaxTimestamp = partition.Timestamp
+			}
+			// Let's end here if partition metrics shall not be exposed
+			if e.minionSvc.Cfg.Topics.Granularity == minion.TopicGranularityTopic {
+				continue
+			}
+			if partition.Timestamp > 0 {
+				ch <- prometheus.MustNewConstMetric(
+					e.partitionMaxTimestamp,
+					prometheus.GaugeValue,
+					float64(partition.Timestamp),
+					topic.Topic,
+					strconv.Itoa(int(partition.Partition)),
+				)
+			}
+		}
+		// We only want to report the max of all partition max timestamps if we receive results from all partitions
+		// and the topic is not empty
+		if !hasErrors && topicMaxTimestamp > 0 {
+			ch <- prometheus.MustNewConstMetric(
+				e.topicMaxTimestamp,
+				prometheus.GaugeValue,
+				float64(topicMaxTimestamp),
+				topic.Topic,
+			)
+		}
+	}
 	return isOk
 }

--- a/prometheus/collect_topic_partition_offsets.go
+++ b/prometheus/collect_topic_partition_offsets.go
@@ -30,7 +30,7 @@ func (e *Exporter) collectTopicPartitionOffsets(ctx context.Context, ch chan<- p
 	// In older versions this is returning the timestamp of the low watermarks (earliest offset)
 	maxTimestampOffsets, err := e.minionSvc.ListOffsetsCached(ctx, -3)
 	if err != nil {
-		e.logger.Warn("failed to fetch offsets for max timestamp", zap.Error(err))
+		e.logger.Error("failed to fetch offsets for max timestamp", zap.Error(err))
 		return false
 	}
 

--- a/prometheus/exporter.go
+++ b/prometheus/exporter.go
@@ -41,6 +41,8 @@ type Exporter struct {
 	partitionHighWaterMark     *prometheus.Desc
 	topicLowWaterMarkSum       *prometheus.Desc
 	partitionLowWaterMark      *prometheus.Desc
+	topicMaxTimestamp          *prometheus.Desc
+	partitionMaxTimestamp      *prometheus.Desc
 
 	// Consumer Groups
 	consumerGroupInfo                    *prometheus.Desc
@@ -169,6 +171,20 @@ func (e *Exporter) InitializeMetrics() {
 	e.topicHighWaterMarkSum = prometheus.NewDesc(
 		prometheus.BuildFQName(e.cfg.Namespace, "kafka", "topic_high_water_mark_sum"),
 		"Sum of all the topic's partition high water marks",
+		[]string{"topic_name"},
+		nil,
+	)
+	// Partition Max Timestamp
+	e.partitionMaxTimestamp = prometheus.NewDesc(
+		prometheus.BuildFQName(e.cfg.Namespace, "kafka", "topic_partition_max_timestamp"),
+		"Partition Max Timestamp",
+		[]string{"topic_name", "partition_id"},
+		nil,
+	)
+	// Topic Max Timestamp
+	e.topicMaxTimestamp = prometheus.NewDesc(
+		prometheus.BuildFQName(e.cfg.Namespace, "kafka", "topic_max_timestamp"),
+		"Topic Max Timestamp",
 		[]string{"topic_name"},
 		nil,
 	)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Kafka 3.0+ added support to fetch offset with the max timestamp.
This is useful in monitoring the steady progress of producing to a topic/partion
but also to detect very high timestamps in the topic that can stuck topic retention.

This patch adds two new metrics:
- `kafka_topic_partition_max_timestamp`: for each topic partition reports the max timestamp in that partition
- `kafka_topic_max_timestamp`: for each topic reports the max timestamp in that topic, computed as the maximum timestamp across partitions


See: 
- https://issues.apache.org/jira/browse/KAFKA-12541
- https://cwiki.apache.org/confluence/display/KAFKA/KIP-734%3A+Improve+AdminClient.listOffsets+to+return+timestamp+and+offset+for+the+record+with+the+largest+timestamp
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
