### PR TITLE
Run as non-root and root group for OpenShift compatibility ADDENDUM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,6 @@ RUN CGO_ENABLED=0 go build \
 FROM alpine:3.17
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/bin/kminion /app/kminion
-RUN chown -R 1001:0 /app/kminion \
-    && chmod -R g=u /app/kminion
-USER 1001
+RUN chmod -R +x /app/kminion
 
 ENTRYPOINT ["/app/kminion"]

--- a/charts/kminion/values.yaml
+++ b/charts/kminion/values.yaml
@@ -28,9 +28,9 @@ podAnnotations: {}
 #  prometheus.io/port: "8080"
 #  prometheus.io/path: "/metrics"
 
-podSecurityContext:
-  runAsUser: 99
-  fsGroup: 99
+podSecurityContext: {}
+  # runAsUser: 99
+  # fsGroup: 99
 
 ## See `kubectl explain poddisruptionbudget.spec` for more
 ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/


### PR DESCRIPTION
Kminion only needs execute permissions.

```
Events:
  Type     Reason        Age                 From                   Message
  ----     ------        ----                ----                   -------
  Warning  FailedCreate  13s (x14 over 44s)  replicaset-controller  Error creating: pods "pipeline-kafka-kafka-minion-5bc5858f59-" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount, provider restricted-v2: .spec.securityContext.fsGroup: Invalid value: []int64{99}: 99 is not an allowed group, spec.containers[0].securityContext.runAsUser: Invalid value: 99: must be in the ranges: [1001160000, 1001169999], provider "restricted": Forbidden: not usable by user or serviceaccount, provider "nonroot-v2": Forbidden: not usable by user or serviceaccount, provider "nonroot": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid": Forbidden: not usable by user or serviceaccount, provider "log-collector-scc": Forbidden: not usable by user or serviceaccount, provider "machine-api-termination-handler": Forbidden: not usable by user or serviceaccount, provider "hostnetwork-v2": Forbidden: not usable by user or serviceaccount, provider "hostnetwork": Forbidden: not usable by user or serviceaccount, provider "hostaccess": Forbidden: not usable by user or serviceaccount, provider "node-exporter": Forbidden: not usable by user or serviceaccount, provider "privileged": Forbidden: not usable by user or serviceaccount, provider "privileged-genevalogging": Forbidden: not usable by user or serviceaccount]
```