### PR TITLE
chore: pin Go to exact patch version (1.26.5)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,9 +10,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  GO_VERSION: '1.26'
-
 jobs:
   test:
     name: Test
@@ -24,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Download dependencies
@@ -53,7 +50,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Run golangci-lint
@@ -72,7 +69,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################################################
 # Build image
 ############################################################
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 ARG VERSION
 ARG BUILT_AT

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudhut/kminion/v2
 
-go 1.26
+go 1.26.5
 
 require (
 	github.com/adobe/ims-go v0.25.0


### PR DESCRIPTION
## Summary
- Pin `go.mod` and `Dockerfile` to `go1.26.5` (current latest patch) instead of the floating `1.26` minor version, for reproducible builds.
- Replace `ci.yaml`'s `GO_VERSION` env var with `go-version-file: 'go.mod'` (matching the pattern already used in `e2e-tests.yaml`), making `go.mod` the single source of truth.

## Why
Renovate's `github-actions` manager cannot resolve `${{ env.GO_VERSION }}` indirection, so the hardcoded env var would silently drift from `go.mod`/`Dockerfile` on future Go patch releases. Deriving CI's Go version from `go.mod` removes the duplication entirely — Renovate only needs to bump one file.

## Test plan
- [x] `go build ./...` passes with the pinned toolchain
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] CI runs green on this PR (test/lint/build/e2e jobs pick up Go 1.26.5 via `go.mod`)