### PR TITLE
fix(core): resolve correctness, security, and reliability bugs in kafka/minion/prometheus packages

### DIFF
--- a/config.go
+++ b/config.go
@@ -42,6 +42,11 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("failed to validate minion config: %w", err)
 	}
 
+	err = c.Exporter.Validate()
+	if err != nil {
+		return fmt.Errorf("failed to validate exporter config: %w", err)
+	}
+
 	err = c.Logger.Validate()
 	if err != nil {
 		return fmt.Errorf("failed to validate logger config: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/knadh/koanf/providers/file v1.2.1
 	github.com/knadh/koanf/v2 v2.3.5
 	github.com/orcaman/concurrent-map/v2 v2.0.1
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
 	github.com/twmb/franz-go v1.21.5

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,6 @@ github.com/orcaman/concurrent-map/v2 v2.0.1/go.mod h1:9Eq3TG2oBe5FirmYWQfYO5iH1q
 github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
 github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=

--- a/kafka/client_config_helper.go
+++ b/kafka/client_config_helper.go
@@ -86,7 +86,7 @@ func NewKgoConfig(cfg Config, logger *zap.Logger) ([]kgo.Opt, error) {
 			}
 
 			switch cfg.SASL.GSSAPI.AuthType {
-			case "USER_AUTH:":
+			case "USER_AUTH":
 				krbClient = client.NewWithPassword(
 					cfg.SASL.GSSAPI.Username,
 					cfg.SASL.GSSAPI.Realm,

--- a/kafka/client_config_helper.go
+++ b/kafka/client_config_helper.go
@@ -23,6 +23,46 @@ import (
 	krbconfig "github.com/jcmturner/gokrb5/v8/config"
 )
 
+// buildGSSAPIMechanism constructs the Kerberos/GSSAPI SASL mechanism for the given config. It
+// returns an error if authType is not one of USER_AUTH or KEYTAB_AUTH, or if the Kerberos config or
+// keytab file cannot be loaded.
+func buildGSSAPIMechanism(cfg SASLGSSAPIConfig) (sasl.Mechanism, error) {
+	kerbCfg, err := krbconfig.Load(cfg.KerberosConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kerberos config from specified config filepath: %w", err)
+	}
+
+	var krbClient *client.Client
+	switch cfg.AuthType {
+	case "USER_AUTH":
+		krbClient = client.NewWithPassword(
+			cfg.Username,
+			cfg.Realm,
+			cfg.Password,
+			kerbCfg,
+			client.DisablePAFXFAST(!cfg.EnableFast))
+	case "KEYTAB_AUTH":
+		ktb, err := keytab.Load(cfg.KeyTabPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load keytab: %w", err)
+		}
+		krbClient = client.NewWithKeytab(
+			cfg.Username,
+			cfg.Realm,
+			ktb,
+			kerbCfg,
+			client.DisablePAFXFAST(!cfg.EnableFast))
+	default:
+		return nil, fmt.Errorf("kafka.sasl.gssapi.authType must be one of USER_AUTH or KEYTAB_AUTH")
+	}
+
+	return kerberos.Auth{
+		Client:           krbClient,
+		Service:          cfg.ServiceName,
+		PersistAfterAuth: true,
+	}.AsMechanism(), nil
+}
+
 // NewKgoConfig creates a new Config for the Kafka Client as exposed by the franz-go library.
 // If TLS certificates can't be read an error will be returned.
 // logger is only used to print warnings about TLS.
@@ -78,42 +118,11 @@ func NewKgoConfig(cfg Config, logger *zap.Logger) ([]kgo.Opt, error) {
 
 		// Kerberos
 		if cfg.SASL.Mechanism == "GSSAPI" {
-			var krbClient *client.Client
-
-			kerbCfg, err := krbconfig.Load(cfg.SASL.GSSAPI.KerberosConfigPath)
+			mechanism, err := buildGSSAPIMechanism(cfg.SASL.GSSAPI)
 			if err != nil {
-				return nil, fmt.Errorf("failed to create kerberos config from specified config filepath: %w", err)
+				return nil, err
 			}
-
-			switch cfg.SASL.GSSAPI.AuthType {
-			case "USER_AUTH":
-				krbClient = client.NewWithPassword(
-					cfg.SASL.GSSAPI.Username,
-					cfg.SASL.GSSAPI.Realm,
-					cfg.SASL.GSSAPI.Password,
-					kerbCfg,
-					client.DisablePAFXFAST(!cfg.SASL.GSSAPI.EnableFast))
-			case "KEYTAB_AUTH":
-				ktb, err := keytab.Load(cfg.SASL.GSSAPI.KeyTabPath)
-				if err != nil {
-					return nil, fmt.Errorf("failed to load keytab: %w", err)
-				}
-				krbClient = client.NewWithKeytab(
-					cfg.SASL.GSSAPI.Username,
-					cfg.SASL.GSSAPI.Realm,
-					ktb,
-					kerbCfg,
-					client.DisablePAFXFAST(!cfg.SASL.GSSAPI.EnableFast))
-			}
-			if krbClient == nil {
-				return nil, fmt.Errorf("kafka.sasl.gssapi.authType must be one of USER_AUTH or KEYTAB_AUTH")
-			}
-			kerberosMechanism := kerberos.Auth{
-				Client:           krbClient,
-				Service:          cfg.SASL.GSSAPI.ServiceName,
-				PersistAfterAuth: true,
-			}.AsMechanism()
-			opts = append(opts, kgo.SASL(kerberosMechanism))
+			opts = append(opts, kgo.SASL(mechanism))
 		}
 
 		// OAuthBearer

--- a/kafka/client_config_helper.go
+++ b/kafka/client_config_helper.go
@@ -215,6 +215,10 @@ func NewKgoConfig(cfg Config, logger *zap.Logger) ([]kgo.Opt, error) {
 			certificates = []tls.Certificate{tlsCert}
 		}
 
+		if cfg.TLS.InsecureSkipTLSVerify {
+			logger.Warn("TLS certificate verification is disabled (insecureSkipTlsVerify=true); " +
+				"the connection to Kafka is vulnerable to man-in-the-middle attacks")
+		}
 		tlsDialer := &tls.Dialer{
 			NetDialer: &net.Dialer{Timeout: 10 * time.Second},
 			Config: &tls.Config{
@@ -238,18 +242,15 @@ func decryptPrivateKey(keyPEM []byte, passphrase string, logger *zap.Logger) ([]
 		return nil, fmt.Errorf("failed to decode PEM block containing private key")
 	}
 
-	// Check if it's an encrypted PKCS#8 key (modern, secure)
+	// PKCS#8 encrypted keys ("ENCRYPTED PRIVATE KEY" PEM blocks) use PBES2, which Go's stdlib
+	// x509.DecryptPEMBlock does not support (it only implements the legacy RFC1423 PEM encryption
+	// scheme). Rather than attempt a decryption that will always fail while confusingly nudging
+	// users toward the insecure legacy format, fail fast with a clear, actionable error.
 	if block.Type == "ENCRYPTED PRIVATE KEY" {
-		// PKCS#8 encrypted keys should be decrypted using x509.ParsePKCS8PrivateKey
-		// which doesn't support password-based decryption directly in stdlib.
-		// For now, we'll use the legacy method with nolint for PKCS#8 as well.
-		// TODO: Consider using golang.org/x/crypto/pkcs12 for proper PKCS#8 support
-		decrypted, err := x509.DecryptPEMBlock(block, []byte(passphrase)) //nolint:staticcheck // No stdlib alternative for PKCS#8 password decryption
-		if err != nil {
-			return nil, fmt.Errorf("failed to decrypt PKCS#8 private key: %w", err)
-		}
-		// Re-encode as unencrypted PKCS#8
-		return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: decrypted}), nil
+		return nil, fmt.Errorf("PKCS#8 encrypted private keys are not supported for password-based " +
+			"decryption; convert your key to the legacy encrypted format instead: " +
+			"openssl pkcs8 -topk8 -v1 PBE-SHA1-3DES -in your_key.pem -out legacy_key.pem, or provide " +
+			"an unencrypted key file")
 	}
 
 	// Check if it's a legacy encrypted PEM block (insecure, deprecated)

--- a/kafka/client_config_helper_pkcs8_test.go
+++ b/kafka/client_config_helper_pkcs8_test.go
@@ -1,0 +1,20 @@
+package kafka
+
+import (
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestDecryptPrivateKey_PKCS8Encrypted_FailsWithClearError(t *testing.T) {
+	// A syntactically-valid "ENCRYPTED PRIVATE KEY" PEM block. The contents don't need to be a real
+	// PKCS#8 structure since we reject this block type before attempting to parse its contents.
+	pemBlock := pem.EncodeToMemory(&pem.Block{Type: "ENCRYPTED PRIVATE KEY", Bytes: []byte("not-real-pkcs8-bytes")})
+
+	_, err := decryptPrivateKey(pemBlock, "somepass", zap.NewNop())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported")
+}

--- a/kafka/client_config_helper_test.go
+++ b/kafka/client_config_helper_test.go
@@ -1,0 +1,46 @@
+package kafka
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeTempKrb5Conf(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "krb5.conf")
+	content := "[libdefaults]\n  default_realm = EXAMPLE.COM\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func TestBuildGSSAPIMechanism_UserAuth(t *testing.T) {
+	cfg := SASLGSSAPIConfig{
+		AuthType:           "USER_AUTH",
+		KerberosConfigPath: writeTempKrb5Conf(t),
+		ServiceName:        "kafka",
+		Username:           "test-user",
+		Password:           "test-pass",
+		Realm:              "EXAMPLE.COM",
+	}
+
+	mechanism, err := buildGSSAPIMechanism(cfg)
+	require.NoError(t, err, "USER_AUTH must be recognized (regression test for the 'USER_AUTH:' typo bug)")
+	assert.NotNil(t, mechanism)
+}
+
+func TestBuildGSSAPIMechanism_InvalidAuthType(t *testing.T) {
+	cfg := SASLGSSAPIConfig{
+		AuthType:           "BOGUS_AUTH",
+		KerberosConfigPath: writeTempKrb5Conf(t),
+		ServiceName:        "kafka",
+	}
+
+	_, err := buildGSSAPIMechanism(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authType must be one of USER_AUTH or KEYTAB_AUTH")
+}

--- a/kafka/client_config_helper_tls_test.go
+++ b/kafka/client_config_helper_tls_test.go
@@ -1,0 +1,31 @@
+package kafka
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestNewKgoConfig_WarnsOnInsecureSkipTLSVerify(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	cfg := Config{
+		TLS: TLSConfig{Enabled: true, InsecureSkipTLSVerify: true},
+	}
+
+	_, err := NewKgoConfig(cfg, logger)
+	require.NoError(t, err)
+
+	found := false
+	for _, entry := range logs.All() {
+		if strings.Contains(entry.Message, "TLS certificate verification is disabled") {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected a warning log when InsecureSkipTLSVerify is enabled")
+}

--- a/kafka/config_sasl.go
+++ b/kafka/config_sasl.go
@@ -36,8 +36,10 @@ func (c *SASLConfig) Validate() error {
 	}
 
 	switch c.Mechanism {
-	case SASLMechanismPlain, SASLMechanismScramSHA256, SASLMechanismScramSHA512, SASLMechanismGSSAPI:
-		// Valid and supported
+	case SASLMechanismPlain, SASLMechanismScramSHA256, SASLMechanismScramSHA512:
+		// Valid and supported, no further config validation needed
+	case SASLMechanismGSSAPI:
+		return c.GSSAPI.Validate()
 	case SASLMechanismOAuthBearer:
 		return c.OAuthBearer.Validate()
 	default:

--- a/kafka/config_sasl_gssapi.go
+++ b/kafka/config_sasl_gssapi.go
@@ -1,5 +1,7 @@
 package kafka
 
+import "fmt"
+
 // SASLGSSAPIConfig represents the Kafka Kerberos config
 type SASLGSSAPIConfig struct {
 	AuthType           string `koanf:"authType"`
@@ -18,4 +20,32 @@ type SASLGSSAPIConfig struct {
 
 func (s *SASLGSSAPIConfig) SetDefaults() {
 	s.EnableFast = true
+}
+
+func (s *SASLGSSAPIConfig) Validate() error {
+	switch s.AuthType {
+	case "USER_AUTH", "KEYTAB_AUTH":
+	default:
+		return fmt.Errorf("kafka.sasl.gssapi.authType must be one of USER_AUTH or KEYTAB_AUTH, got '%s'", s.AuthType)
+	}
+
+	if s.KerberosConfigPath == "" {
+		return fmt.Errorf("kafka.sasl.gssapi.kerberosConfigPath must be set")
+	}
+	if s.ServiceName == "" {
+		return fmt.Errorf("kafka.sasl.gssapi.serviceName must be set")
+	}
+
+	switch s.AuthType {
+	case "USER_AUTH":
+		if s.Username == "" || s.Password == "" || s.Realm == "" {
+			return fmt.Errorf("kafka.sasl.gssapi.authType USER_AUTH requires username, password and realm to be set")
+		}
+	case "KEYTAB_AUTH":
+		if s.KeyTabPath == "" || s.Username == "" || s.Realm == "" {
+			return fmt.Errorf("kafka.sasl.gssapi.authType KEYTAB_AUTH requires keyTabPath, username and realm to be set")
+		}
+	}
+
+	return nil
 }

--- a/kafka/config_sasl_gssapi_test.go
+++ b/kafka/config_sasl_gssapi_test.go
@@ -1,0 +1,46 @@
+package kafka
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSASLGSSAPIConfig_Validate(t *testing.T) {
+	t.Run("valid USER_AUTH config passes", func(t *testing.T) {
+		cfg := SASLGSSAPIConfig{
+			AuthType:           "USER_AUTH",
+			KerberosConfigPath: "/etc/krb5.conf",
+			ServiceName:        "kafka",
+			Username:           "user",
+			Password:           "pass",
+			Realm:              "EXAMPLE.COM",
+		}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("valid KEYTAB_AUTH config passes", func(t *testing.T) {
+		cfg := SASLGSSAPIConfig{
+			AuthType:           "KEYTAB_AUTH",
+			KerberosConfigPath: "/etc/krb5.conf",
+			ServiceName:        "kafka",
+			KeyTabPath:         "/etc/kafka.keytab",
+			Username:           "user",
+			Realm:              "EXAMPLE.COM",
+		}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("unknown authType is rejected", func(t *testing.T) {
+		cfg := SASLGSSAPIConfig{AuthType: "BOGUS", KerberosConfigPath: "/etc/krb5.conf", ServiceName: "kafka"}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "USER_AUTH or KEYTAB_AUTH")
+	})
+
+	t.Run("missing kerberosConfigPath is rejected", func(t *testing.T) {
+		cfg := SASLGSSAPIConfig{AuthType: "USER_AUTH", ServiceName: "kafka", Username: "u", Password: "p", Realm: "R"}
+		require.Error(t, cfg.Validate())
+	})
+}

--- a/kafka/config_sasl_oauthbearer.go
+++ b/kafka/config_sasl_oauthbearer.go
@@ -89,9 +89,15 @@ func (c *OAuthBearerConfig) getTokenWithTimeout(ctx context.Context, timeout tim
 
 // Validate validates the OAuthBearerConfig
 func (c *OAuthBearerConfig) Validate() error {
-	// Common validation for all OAuth types
 	if c.TokenEndpoint == "" {
 		return fmt.Errorf("OAuthBearer token endpoint is not specified")
+	}
+	parsedURL, err := url.Parse(c.TokenEndpoint)
+	if err != nil {
+		return fmt.Errorf("OAuthBearer token endpoint is not a valid URL: %w", err)
+	}
+	if parsedURL.Scheme != "https" {
+		return fmt.Errorf("OAuthBearer token endpoint must use https, got scheme '%s'", parsedURL.Scheme)
 	}
 	if c.ClientID == "" || c.ClientSecret == "" {
 		return fmt.Errorf("OAuthBearer client credentials are not specified")

--- a/kafka/config_sasl_oauthbearer.go
+++ b/kafka/config_sasl_oauthbearer.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 // OAuthBearerConfig represents the OAUTHBEARER SASL config with support for different providers
@@ -31,8 +32,16 @@ type OAuthAdditionalConfig struct {
 	ClientCode string `koanf:"clientCode"`
 }
 
+// defaultOAuthTokenTimeout bounds how long a single generic OAuth token request may take. Without
+// this, a stalled token endpoint would block the SASL auth callback indefinitely.
+const defaultOAuthTokenTimeout = 30 * time.Second
+
 // same as AcquireToken in Console https://github.com/redpanda-data/console/blob/master/backend/pkg/config/kafka_sasl_oauth.go#L56
 func (c *OAuthBearerConfig) getToken(ctx context.Context) (string, error) {
+	return c.getTokenWithTimeout(ctx, defaultOAuthTokenTimeout)
+}
+
+func (c *OAuthBearerConfig) getTokenWithTimeout(ctx context.Context, timeout time.Duration) (string, error) {
 	authHeaderValue := base64.StdEncoding.EncodeToString([]byte(c.ClientID + ":" + c.ClientSecret))
 
 	queryParams := url.Values{
@@ -50,7 +59,7 @@ func (c *OAuthBearerConfig) getToken(ctx context.Context) (string, error) {
 	req.Header.Set("Authorization", "Basic "+authHeaderValue)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: timeout}
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/kafka/config_sasl_oauthbearer_test.go
+++ b/kafka/config_sasl_oauthbearer_test.go
@@ -1,7 +1,15 @@
 package kafka
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOAuthBearerConfig_GenericOAuth(t *testing.T) {
@@ -146,4 +154,38 @@ func TestSASLConfig_ValidateOAuthBearer_UnknownType(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for unknown OAuth type")
 	}
+}
+
+func TestOAuthBearerConfig_GetToken_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"access_token": "test-token-123"})
+	}))
+	defer server.Close()
+
+	cfg := OAuthBearerConfig{
+		TokenEndpoint: server.URL,
+		ClientID:      "client",
+		ClientSecret:  "secret",
+	}
+
+	token, err := cfg.getToken(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "test-token-123", token)
+}
+
+func TestOAuthBearerConfig_GetToken_RespectsTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		_ = json.NewEncoder(w).Encode(map[string]string{"access_token": "too-late"})
+	}))
+	defer server.Close()
+
+	cfg := OAuthBearerConfig{
+		TokenEndpoint: server.URL,
+		ClientID:      "client",
+		ClientSecret:  "secret",
+	}
+
+	_, err := cfg.getTokenWithTimeout(context.Background(), 50*time.Millisecond)
+	require.Error(t, err, "expected a client-side timeout error when the token endpoint is slower than the configured timeout")
 }

--- a/kafka/config_sasl_oauthbearer_test.go
+++ b/kafka/config_sasl_oauthbearer_test.go
@@ -189,3 +189,14 @@ func TestOAuthBearerConfig_GetToken_RespectsTimeout(t *testing.T) {
 	_, err := cfg.getTokenWithTimeout(context.Background(), 50*time.Millisecond)
 	require.Error(t, err, "expected a client-side timeout error when the token endpoint is slower than the configured timeout")
 }
+
+func TestOAuthBearerConfig_Validate_RejectsNonHTTPSEndpoint(t *testing.T) {
+	config := OAuthBearerConfig{
+		TokenEndpoint: "http://oauth.example.com/token",
+		ClientID:      "test-client",
+		ClientSecret:  "test-secret",
+	}
+	err := config.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "https")
+}

--- a/kafka/oauth_adobe_ims.go
+++ b/kafka/oauth_adobe_ims.go
@@ -274,20 +274,16 @@ func (a *AdobeImsOAuthBearer) refreshTokenIfNeeded(ctx context.Context) error {
 		return nil
 	}
 
-	// Upgrade to write lock for refresh
-	a.mu.Lock()
-	defer a.mu.Unlock()
-
-	// Double-check after acquiring write lock (another goroutine might have refreshed)
-	timeUntilExpiry = time.Until(a.expiresAt)
-	if timeUntilExpiry >= tokenRefreshThreshold {
-		return nil
-	}
-
-	// Calculate retry configuration based on urgency
 	config := calculateRetryConfig(timeUntilExpiry)
 
-	// Refresh the token with adaptive retry logic
+	// Perform the network refresh WITHOUT holding the lock, so concurrent SASL auth callbacks
+	// reading the current (still-valid) token are not blocked behind a slow or retrying IMS call.
+	var (
+		newAccessToken      string
+		newRefreshToken     string
+		newExpiresAt        time.Time
+		refreshTokenRenewed bool
+	)
 	err := retryWithBackoffAndConfig(ctx, func() error {
 		refreshResp, err := a.client.RefreshTokenWithContext(ctx, &ims.RefreshTokenRequest{
 			RefreshToken: currentRefreshToken,
@@ -298,34 +294,42 @@ func (a *AdobeImsOAuthBearer) refreshTokenIfNeeded(ctx context.Context) error {
 			return err
 		}
 
-		// Update token state
-		a.accessToken = refreshResp.AccessToken
-		refreshTokenRenewed := false
+		newAccessToken = refreshResp.AccessToken
+		newExpiresAt = time.Now().Add(refreshResp.ExpiresIn)
 		if refreshResp.RefreshToken != "" {
-			a.refreshToken = refreshResp.RefreshToken
+			newRefreshToken = refreshResp.RefreshToken
 			refreshTokenRenewed = true
 		}
-		a.expiresAt = time.Now().Add(refreshResp.ExpiresIn)
-
-		// Log token refresh
-		refreshAt := a.expiresAt.Add(-tokenRefreshThreshold)
-		if refreshTokenRenewed {
-			a.logger.Info("refresh token renewed",
-				zap.Time("new_expires_at", a.expiresAt),
-				zap.Duration("expires_in", refreshResp.ExpiresIn),
-				zap.Time("refresh_at", refreshAt))
-		} else {
-			a.logger.Info("access token refreshed",
-				zap.Time("new_expires_at", a.expiresAt),
-				zap.Duration("expires_in", refreshResp.ExpiresIn),
-				zap.Time("refresh_at", refreshAt))
-		}
-
 		return nil
 	}, config)
-
 	if err != nil {
 		return fmt.Errorf("failed to refresh IMS token after retries: %w", err)
+	}
+
+	// Take the write lock only to swap in the new token/expiry. Re-check whether another goroutine
+	// already refreshed to a later expiry while we were doing our own network call.
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.expiresAt.After(newExpiresAt) {
+		return nil
+	}
+	a.accessToken = newAccessToken
+	if refreshTokenRenewed {
+		a.refreshToken = newRefreshToken
+	}
+	a.expiresAt = newExpiresAt
+
+	refreshAt := a.expiresAt.Add(-tokenRefreshThreshold)
+	if refreshTokenRenewed {
+		a.logger.Info("refresh token renewed",
+			zap.Time("new_expires_at", a.expiresAt),
+			zap.Duration("expires_in", newExpiresAt.Sub(time.Now())),
+			zap.Time("refresh_at", refreshAt))
+	} else {
+		a.logger.Info("access token refreshed",
+			zap.Time("new_expires_at", a.expiresAt),
+			zap.Duration("expires_in", newExpiresAt.Sub(time.Now())),
+			zap.Time("refresh_at", refreshAt))
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func main() {
 			wrappedRegisterer,
 		)
 		if err != nil {
-			logger.Fatal("failed to create end-to-end monitoring service: %w", zap.Error(err))
+			logger.Fatal("failed to create end-to-end monitoring service", zap.Error(err))
 		}
 
 		if err = e2eService.Start(ctx); err != nil {

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/cloudhut/kminion/v2/e2e"
 	"github.com/cloudhut/kminion/v2/kafka"
@@ -117,7 +118,10 @@ func main() {
 
 	// Start HTTP server
 	address := net.JoinHostPort(cfg.Exporter.Host, strconv.Itoa(cfg.Exporter.Port))
-	srv := &http.Server{Addr: address}
+	srv := &http.Server{
+		Addr:              address,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
 	go func() {
 		<-ctx.Done()
 		if err := srv.Shutdown(context.Background()); err != nil {

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"syscall"
 
 	"github.com/cloudhut/kminion/v2/e2e"
 	"github.com/cloudhut/kminion/v2/kafka"
@@ -56,7 +57,7 @@ func main() {
 		logger.Fatal("failed to set GOMAXPROCS automatically", zap.Error(err))
 	}
 	// Setup context that stops when the application receives an interrupt signal
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	wrappedRegisterer := promclient.WrapRegistererWithPrefix(cfg.Exporter.Namespace+"_", promclient.DefaultRegisterer)

--- a/minion/config_consumer_group.go
+++ b/minion/config_consumer_group.go
@@ -4,12 +4,18 @@ import (
 	"fmt"
 )
 
-const (
-	ConsumerGroupScrapeModeOffsetsTopic string = "offsetsTopic"
-	ConsumerGroupScrapeModeAdminAPI     string = "adminApi"
+type ConsumerGroupScrapeMode string
 
-	ConsumerGroupGranularityTopic     string = "topic"
-	ConsumerGroupGranularityPartition string = "partition"
+const (
+	ConsumerGroupScrapeModeOffsetsTopic ConsumerGroupScrapeMode = "offsetsTopic"
+	ConsumerGroupScrapeModeAdminAPI     ConsumerGroupScrapeMode = "adminApi"
+)
+
+type ConsumerGroupGranularity string
+
+const (
+	ConsumerGroupGranularityTopic     ConsumerGroupGranularity = "topic"
+	ConsumerGroupGranularityPartition ConsumerGroupGranularity = "partition"
 )
 
 type ConsumerGroupConfig struct {
@@ -18,12 +24,12 @@ type ConsumerGroupConfig struct {
 
 	// Mode specifies whether we export consumer group offsets using the Admin API or by consuming the internal
 	// __consumer_offsets topic.
-	ScrapeMode string `koanf:"scrapeMode"`
+	ScrapeMode ConsumerGroupScrapeMode `koanf:"scrapeMode"`
 
 	// Granularity can be per topic or per partition. If you want to reduce the number of exported metric series and
 	// you aren't interested in per partition lags you could choose "topic" where all partition lags will be summed
 	// and only topic lags will be exported.
-	Granularity string `koanf:"granularity"`
+	Granularity ConsumerGroupGranularity `koanf:"granularity"`
 
 	// AllowedGroups are regex strings of group ids that shall be exported
 	AllowedGroupIDs []string `koanf:"allowedGroups"`

--- a/minion/consumer_group_offsets.go
+++ b/minion/consumer_group_offsets.go
@@ -31,16 +31,22 @@ func (s *Service) ListAllConsumerGroupOffsetsAdminAPI(ctx context.Context) (map[
 	return s.listConsumerGroupOffsetsBulk(ctx, groupIDs)
 }
 
+// maxConcurrentGroupOffsetRequests bounds how many concurrent OffsetFetch requests are issued when
+// bulk-fetching consumer group offsets, to avoid a thundering herd against Kafka coordinators on
+// clusters with many consumer groups.
+const maxConcurrentGroupOffsetRequests = 50
+
 // listConsumerGroupOffsetsBulk returns a map which has the Consumer group name as key
 func (s *Service) listConsumerGroupOffsetsBulk(ctx context.Context, groups []string) (map[string]*kmsg.OffsetFetchResponse, error) {
-	eg, _ := errgroup.WithContext(ctx)
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.SetLimit(maxConcurrentGroupOffsetRequests)
 
 	mutex := sync.Mutex{}
 	res := make(map[string]*kmsg.OffsetFetchResponse)
 
 	f := func(group string) func() error {
 		return func() error {
-			offsets, err := s.listConsumerGroupOffsets(ctx, group)
+			offsets, err := s.listConsumerGroupOffsets(egCtx, group)
 			if err != nil {
 				s.logger.Warn("failed to fetch consumer group offsets, inner kafka error",
 					zap.String("consumer_group", group),

--- a/minion/describe_consumer_groups.go
+++ b/minion/describe_consumer_groups.go
@@ -32,16 +32,10 @@ func (s *Service) listConsumerGroupsCached(ctx context.Context) (*GroupsInfo, er
 		if err != nil {
 			return nil, err
 		}
-		allowedGroups := make([]kmsg.ListGroupsResponseGroup, 0)
-
-		for i := range res.Groups {
-			if s.IsGroupAllowed(res.Groups[i].Group, res.Groups[i].GroupState) {
-				allowedGroups = append(allowedGroups, res.Groups[i])
-			}
-		}
+		total, allowedGroups := s.filterAllowedGroups(res.Groups)
 		res.Groups = allowedGroups
 		groups := &GroupsInfo{
-			AllGroupsCount: len(res.Groups),
+			AllGroupsCount: total,
 			AllowedGroups:  res,
 		}
 		s.setCachedItem(keyAllowedGroups, groups, 120*time.Second)
@@ -53,6 +47,20 @@ func (s *Service) listConsumerGroupsCached(ctx context.Context) (*GroupsInfo, er
 	}
 
 	return groups.(*GroupsInfo), nil
+}
+
+// filterAllowedGroups splits groups into the total count (before filtering) and the subset allowed
+// by IsGroupAllowed. Keeping the total separate from the filtered slice prevents the count from
+// silently becoming "count of allowed groups" if the filtering logic changes later.
+func (s *Service) filterAllowedGroups(groups []kmsg.ListGroupsResponseGroup) (total int, allowed []kmsg.ListGroupsResponseGroup) {
+	total = len(groups)
+	allowed = make([]kmsg.ListGroupsResponseGroup, 0, total)
+	for i := range groups {
+		if s.IsGroupAllowed(groups[i].Group, groups[i].GroupState) {
+			allowed = append(allowed, groups[i])
+		}
+	}
+	return total, allowed
 }
 
 func (s *Service) listConsumerGroups(ctx context.Context) (*kmsg.ListGroupsResponse, error) {

--- a/minion/describe_consumer_groups_test.go
+++ b/minion/describe_consumer_groups_test.go
@@ -1,0 +1,28 @@
+package minion
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+func TestFilterAllowedGroups_TotalCountIsUnfiltered(t *testing.T) {
+	s := &Service{
+		AllowedGroupIDsExpr: []*regexp.Regexp{regexp.MustCompile("^allowed-.*")},
+	}
+
+	groups := []kmsg.ListGroupsResponseGroup{
+		{Group: "allowed-1"},
+		{Group: "allowed-2"},
+		{Group: "denied-1"},
+		{Group: "denied-2"},
+		{Group: "denied-3"},
+	}
+
+	total, allowed := s.filterAllowedGroups(groups)
+
+	assert.Equal(t, 5, total, "total must count ALL groups seen by the cluster, not just allowed ones")
+	assert.Len(t, allowed, 2, "only groups matching the allow-list should be returned")
+}

--- a/minion/describe_topic_config.go
+++ b/minion/describe_topic_config.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 func (s *Service) GetTopicConfigs(ctx context.Context) (*kmsg.DescribeConfigsResponse, error) {
 	metadata, err := s.GetMetadataCached(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get metadata")
+		return nil, fmt.Errorf("failed to get metadata: %w", err)
 	}
 
 	req := kmsg.NewDescribeConfigsRequest()

--- a/minion/offset_consumer.go
+++ b/minion/offset_consumer.go
@@ -49,6 +49,21 @@ func (s *Service) startConsumingOffsets(ctx context.Context) {
 	}
 }
 
+// partitionLag computes how far behind (in messages) a partition's offset consumer is. hasConsumed
+// =false means nothing has been consumed from this partition yet (as opposed to having consumed
+// record 0), which must not be treated as caught up -- a Go map's zero-value lookup can't tell the
+// two cases apart, so callers must pass the map's "ok" result through as hasConsumed.
+func partitionLag(highWaterMark int64, consumedOffset int64, hasConsumed bool) int64 {
+	if !hasConsumed {
+		consumedOffset = -1
+	}
+	lag := highWaterMark - consumedOffset
+	if lag < 0 {
+		lag = 0
+	}
+	return lag
+}
+
 // checkIfConsumerLagIsCaughtUp fetches the newest partition offsets for all partitions in the __consumer_offsets
 // topic and compares these against the last consumed messages from our offset consumer. If the consumed offsets are
 // higher than the partition offsets this means we caught up the initial lag and can mark our storage as ready. A ready
@@ -138,27 +153,25 @@ func (s *Service) checkIfConsumerLagIsCaughtUp(ctx context.Context) {
 				s.logger.Warn("failed to check if consumer lag on offsets metadataReqTopic is caught up because high "+
 					"watermark request failed, with an inner error",
 					zap.Error(err))
+				continue
 			}
 
 			highWaterMark := partition.Offset - 1
-			consumedOffset := consumedOffsets[partition.Partition]
-			partitionLag := highWaterMark - consumedOffset
-			if partitionLag < 0 {
-				partitionLag = 0
-			}
+			consumedOffset, hasConsumed := consumedOffsets[partition.Partition]
+			partLag := partitionLag(highWaterMark, consumedOffset, hasConsumed)
 
-			if partitionLag > 0 {
+			if partLag > 0 {
 				partitionsLagging = append(partitionsLagging, laggingParition{
 					Name: topicRes.Topic,
 					Id:   partition.Partition,
-					Lag:  partitionLag,
+					Lag:  partLag,
 				})
-				totalLag += partitionLag
+				totalLag += partLag
 				s.logger.Debug("consumer_offsets metadataReqTopic lag has not been caught up yet",
 					zap.Int32("partition_id", partition.Partition),
 					zap.Int64("high_water_mark", highWaterMark),
 					zap.Int64("consumed_offset", consumedOffset),
-					zap.Int64("partition_lag", partitionLag))
+					zap.Int64("partition_lag", partLag))
 				isReady = false
 				continue
 			}

--- a/minion/offset_consumer.go
+++ b/minion/offset_consumer.go
@@ -54,8 +54,15 @@ func (s *Service) startConsumingOffsets(ctx context.Context) {
 // higher than the partition offsets this means we caught up the initial lag and can mark our storage as ready. A ready
 // store will start to expose consumer group offsets.
 func (s *Service) checkIfConsumerLagIsCaughtUp(ctx context.Context) {
+	ticker := time.NewTicker(12 * time.Second)
+	defer ticker.Stop()
+
 	for {
-		time.Sleep(12 * time.Second)
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
 		s.logger.Debug("checking if lag in consumer offsets metadataReqTopic is caught up")
 
 		// 1. Get metadataReqTopic high watermarks for __consumer_offsets metadataReqTopic
@@ -67,6 +74,9 @@ func (s *Service) checkIfConsumerLagIsCaughtUp(ctx context.Context) {
 
 		res, err := metadataReq.RequestWith(ctx, s.client)
 		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
 			s.logger.Warn("failed to check if consumer lag on offsets metadataReqTopic is caught up because metadata request failed",
 				zap.Error(err))
 			continue
@@ -92,6 +102,9 @@ func (s *Service) checkIfConsumerLagIsCaughtUp(ctx context.Context) {
 		offsetReq.Topics = topicReqs
 		highMarksRes, err := offsetReq.RequestWith(ctx, s.client)
 		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
 			s.logger.Warn("failed to check if consumer lag on offsets metadataReqTopic is caught up because high watermark request failed",
 				zap.Error(err))
 			continue
@@ -103,7 +116,11 @@ func (s *Service) checkIfConsumerLagIsCaughtUp(ctx context.Context) {
 
 		// 3. Check if high watermarks have been consumed. To avoid a race condition here we will wait some time before
 		// comparing, so that the consumer has enough time to catch up to the new high watermarks we just fetched.
-		time.Sleep(3 * time.Second)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(3 * time.Second):
+		}
 		consumedOffsets := s.storage.getConsumedOffsets()
 		topicRes := highMarksRes.Topics[0]
 		isReady := true

--- a/minion/offset_consumer_test.go
+++ b/minion/offset_consumer_test.go
@@ -1,0 +1,27 @@
+package minion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPartitionLag(t *testing.T) {
+	t.Run("never-consumed single-record partition is NOT considered caught up", func(t *testing.T) {
+		// LEO=1 -> highWaterMark = partition.Offset-1 = 0
+		lag := partitionLag(0, 0, false)
+		assert.Greater(t, lag, int64(0), "a partition that has never been consumed must not report zero lag")
+	})
+
+	t.Run("consumed exactly up to the high water mark has zero lag", func(t *testing.T) {
+		assert.Equal(t, int64(0), partitionLag(10, 10, true))
+	})
+
+	t.Run("lag never goes negative even if consumed offset raced ahead", func(t *testing.T) {
+		assert.Equal(t, int64(0), partitionLag(10, 15, true))
+	})
+
+	t.Run("partial lag is reported correctly", func(t *testing.T) {
+		assert.Equal(t, int64(6), partitionLag(10, 4, true))
+	})
+}

--- a/minion/service.go
+++ b/minion/service.go
@@ -28,6 +28,7 @@ type Service struct {
 	// requestGroup is used to deduplicate multiple concurrent requests to kafka
 	requestGroup *singleflight.Group
 	cache        map[string]interface{}
+	cacheTimers  map[string]*time.Timer
 	cacheLock    sync.RWMutex
 
 	AllowedGroupIDsExpr []*regexp.Regexp
@@ -96,6 +97,7 @@ func NewService(cfg Config, logger *zap.Logger, kafkaSvc *kafka.Service, metrics
 
 		requestGroup: &singleflight.Group{},
 		cache:        make(map[string]interface{}),
+		cacheTimers:  make(map[string]*time.Timer),
 		cacheLock:    sync.RWMutex{},
 
 		AllowedGroupIDsExpr: allowedGroupIDsExpr,
@@ -194,12 +196,14 @@ func (s *Service) setCachedItem(key string, val interface{}, timeout time.Durati
 	s.cacheLock.Lock()
 	defer s.cacheLock.Unlock()
 
-	go func() {
-		time.Sleep(timeout)
-		s.deleteCachedItem(key)
-	}()
+	if existingTimer, exists := s.cacheTimers[key]; exists {
+		existingTimer.Stop()
+	}
 
 	s.cache[key] = val
+	s.cacheTimers[key] = time.AfterFunc(timeout, func() {
+		s.deleteCachedItem(key)
+	})
 }
 
 func (s *Service) deleteCachedItem(key string) {

--- a/minion/service.go
+++ b/minion/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/kversion"
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
 
@@ -37,6 +38,12 @@ type Service struct {
 	client    *kgo.Client
 	admClient *kadm.Client
 	storage   *Storage
+
+	// logDirsSupported tracks whether the connected Kafka cluster supports the DescribeLogDirs API, as
+	// determined by ensureCompatibility(). Read via IsLogDirsEnabled() instead of Cfg.LogDirs.Enabled
+	// directly -- Cfg is treated as read-only static configuration after construction, and mutating it
+	// at runtime (as ensureCompatibility used to do) is not safe for concurrent readers.
+	logDirsSupported *atomic.Bool
 }
 
 func NewService(cfg Config, logger *zap.Logger, kafkaSvc *kafka.Service, metricsNamespace string, ctx context.Context) (*Service, error) {
@@ -99,7 +106,8 @@ func NewService(cfg Config, logger *zap.Logger, kafkaSvc *kafka.Service, metrics
 		client:    client,
 		admClient: kadm.NewClient(client),
 
-		storage: storage,
+		storage:          storage,
+		logDirsSupported: atomic.NewBool(cfg.LogDirs.Enabled),
 	}
 
 	return service, nil
@@ -161,11 +169,17 @@ func (s *Service) ensureCompatibility(ctx context.Context) error {
 		if !isSupported {
 			s.logger.Warn("describing log dirs is enabled, but it is not supported because your Kafka cluster " +
 				"version is too old. feature will be disabled")
-			s.Cfg.LogDirs.Enabled = false
+			s.logDirsSupported.Store(false)
 		}
 	}
 
 	return nil
+}
+
+// IsLogDirsEnabled reports whether log dirs collection is enabled and supported by the connected
+// cluster. Safe for concurrent use, unlike reading Cfg.LogDirs.Enabled directly.
+func (s *Service) IsLogDirsEnabled() bool {
+	return s.logDirsSupported.Load()
 }
 
 func (s *Service) getCachedItem(key string) (interface{}, bool) {

--- a/minion/service_cache_test.go
+++ b/minion/service_cache_test.go
@@ -1,0 +1,29 @@
+package minion
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_SetCachedItem_ResetPreventsEarlyEviction(t *testing.T) {
+	s := &Service{
+		cache:       make(map[string]interface{}),
+		cacheTimers: make(map[string]*time.Timer),
+	}
+
+	s.setCachedItem("k", "first", 30*time.Millisecond)
+	time.Sleep(15 * time.Millisecond)
+	s.setCachedItem("k", "second", 30*time.Millisecond) // resets the deadline
+
+	time.Sleep(20 * time.Millisecond) // ~35ms since first set -- old code would have evicted here
+	val, exists := s.getCachedItem("k")
+	require.True(t, exists, "resetting the key should have cancelled the earlier deleter")
+	assert.Equal(t, "second", val)
+
+	time.Sleep(20 * time.Millisecond) // ~40ms since the second set -- should now be expired
+	_, exists = s.getCachedItem("k")
+	assert.False(t, exists, "the key should eventually expire")
+}

--- a/minion/service_test.go
+++ b/minion/service_test.go
@@ -1,0 +1,27 @@
+package minion
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
+)
+
+func TestService_LogDirsEnabled_ConcurrentAccessNoRace(t *testing.T) {
+	s := &Service{logDirsSupported: atomic.NewBool(true)}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		s.logDirsSupported.Store(false)
+	}()
+	go func() {
+		defer wg.Done()
+		_ = s.IsLogDirsEnabled()
+	}()
+	wg.Wait()
+
+	assert.False(t, s.IsLogDirsEnabled())
+}

--- a/minion/storage_test.go
+++ b/minion/storage_test.go
@@ -1,0 +1,77 @@
+package minion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+	"go.uber.org/zap"
+)
+
+func TestStorage_IsReady_DefaultsFalse(t *testing.T) {
+	s, err := newStorage(zap.NewNop())
+	require.NoError(t, err)
+	assert.False(t, s.isReady())
+}
+
+func TestStorage_SetReadyState(t *testing.T) {
+	s, err := newStorage(zap.NewNop())
+	require.NoError(t, err)
+
+	s.setReadyState(true)
+	assert.True(t, s.isReady())
+
+	s.setReadyState(false)
+	assert.False(t, s.isReady())
+}
+
+func TestStorage_AddAndDeleteOffsetCommit(t *testing.T) {
+	s, err := newStorage(zap.NewNop())
+	require.NoError(t, err)
+	s.setReadyState(true)
+
+	key := kmsg.OffsetCommitKey{Group: "g1", Topic: "t1", Partition: 0}
+	value := kmsg.OffsetCommitValue{Offset: 42, CommitTimestamp: 1000}
+
+	s.addOffsetCommit(key, value)
+
+	offsets := s.getGroupOffsets(func(groupName, groupState string) bool { return true })
+	require.Contains(t, offsets, "g1")
+	require.Contains(t, offsets["g1"], "t1")
+	commit := offsets["g1"]["t1"][0]
+	assert.Equal(t, int64(42), commit.Value.Offset)
+	assert.Equal(t, 1, commit.CommitCount)
+
+	// Committing again to the same group/topic/partition increments CommitCount.
+	s.addOffsetCommit(key, value)
+	offsets = s.getGroupOffsets(func(groupName, groupState string) bool { return true })
+	assert.Equal(t, 2, offsets["g1"]["t1"][0].CommitCount)
+
+	s.deleteOffsetCommit(key)
+	offsets = s.getGroupOffsets(func(groupName, groupState string) bool { return true })
+	assert.NotContains(t, offsets, "g1")
+}
+
+func TestStorage_GetGroupOffsets_NotReady_ReturnsEmpty(t *testing.T) {
+	s, err := newStorage(zap.NewNop())
+	require.NoError(t, err)
+	// storage starts not-ready; offsets must not be exposed yet even if some exist.
+	s.addOffsetCommit(kmsg.OffsetCommitKey{Group: "g1", Topic: "t1", Partition: 0}, kmsg.OffsetCommitValue{Offset: 1})
+
+	offsets := s.getGroupOffsets(func(groupName, groupState string) bool { return true })
+	assert.Empty(t, offsets)
+}
+
+func TestStorage_MarkRecordConsumed_TracksProgress(t *testing.T) {
+	s, err := newStorage(zap.NewNop())
+	require.NoError(t, err)
+
+	s.markRecordConsumed(&kgo.Record{Partition: 3, Offset: 99})
+
+	consumed := s.getConsumedOffsets()
+	require.Contains(t, consumed, int32(3))
+	assert.Equal(t, int64(99), consumed[3])
+	assert.Equal(t, float64(1), s.getNumberOfConsumedRecords())
+}

--- a/prometheus/collect_consumer_group_lags.go
+++ b/prometheus/collect_consumer_group_lags.go
@@ -60,7 +60,7 @@ type partitionOffsetLag struct {
 // topic. Callers must only call this when topicMarks is non-nil (known watermarks) -- when a topic
 // has no watermarks at all, the caller should skip calling this and omit the aggregate series
 // entirely rather than reporting a misleading lag of 0.
-func (e *Exporter) emitTopicLag(ch chan<- prometheus.Metric, groupName, topicName string, offsets []partitionOffsetLag, topicMarks map[int32]waterMark, granularity string) (totalCommitCount int) {
+func (e *Exporter) emitTopicLag(ch chan<- prometheus.Metric, groupName, topicName string, offsets []partitionOffsetLag, topicMarks map[int32]waterMark, granularity minion.ConsumerGroupGranularity) (totalCommitCount int) {
 	topicLag := float64(0)
 	topicOffsetSum := float64(0)
 	for _, po := range offsets {

--- a/prometheus/collect_consumer_group_lags.go
+++ b/prometheus/collect_consumer_group_lags.go
@@ -48,67 +48,69 @@ func (e *Exporter) collectConsumerGroupLags(ctx context.Context, ch chan<- prome
 	}
 }
 
+// partitionOffsetLag is a normalized view of one partition's committed offset, used to share lag
+// aggregation logic between the AdminAPI and offsets-topic scrape modes.
+type partitionOffsetLag struct {
+	PartitionID int32
+	GroupOffset int64
+	CommitCount int // only meaningful for the offsets-topic path; zero for AdminAPI
+}
+
+// emitTopicLag computes and emits the per-partition and topic-aggregate lag metrics for one group's
+// topic. Callers must only call this when topicMarks is non-nil (known watermarks) -- when a topic
+// has no watermarks at all, the caller should skip calling this and omit the aggregate series
+// entirely rather than reporting a misleading lag of 0.
+func (e *Exporter) emitTopicLag(ch chan<- prometheus.Metric, groupName, topicName string, offsets []partitionOffsetLag, topicMarks map[int32]waterMark, granularity string) (totalCommitCount int) {
+	topicLag := float64(0)
+	topicOffsetSum := float64(0)
+	for _, po := range offsets {
+		partitionMark, exists := topicMarks[po.PartitionID]
+		if !exists {
+			e.logger.Warn("consumer group has committed offsets on a partition we don't have watermarks for",
+				zap.String("consumer_group", groupName),
+				zap.String("topic_name", topicName),
+				zap.Int32("partition_id", po.PartitionID),
+				zap.Int64("group_offset", po.GroupOffset))
+			continue
+		}
+		lag := math.Max(0, float64(partitionMark.HighWaterMark-po.GroupOffset))
+		topicLag += lag
+		topicOffsetSum += float64(po.GroupOffset)
+		totalCommitCount += po.CommitCount
+
+		if granularity == minion.ConsumerGroupGranularityTopic {
+			continue
+		}
+		ch <- prometheus.MustNewConstMetric(
+			e.consumerGroupTopicPartitionLag, prometheus.GaugeValue, lag, groupName, topicName, strconv.Itoa(int(po.PartitionID)),
+		)
+	}
+
+	ch <- prometheus.MustNewConstMetric(e.consumerGroupTopicLag, prometheus.GaugeValue, topicLag, groupName, topicName)
+	ch <- prometheus.MustNewConstMetric(e.consumerGroupTopicOffsetSum, prometheus.GaugeValue, topicOffsetSum, groupName, topicName)
+	return totalCommitCount
+}
+
 func (e *Exporter) collectConsumerGroupLagsOffsetTopic(_ context.Context, ch chan<- prometheus.Metric, marks map[string]map[int32]waterMark) bool {
 	offsets := e.minionSvc.ListAllConsumerGroupOffsetsInternal()
 	for groupName, group := range offsets {
 		offsetCommits := 0
-
 		for topicName, topic := range group {
-			topicLag := float64(0)
-			topicOffsetSum := float64(0)
-			for partitionID, partition := range topic {
-				childLogger := e.logger.With(
-					zap.String("consumer_group", groupName),
-					zap.String("topic_name", topicName),
-					zap.Int32("partition_id", partitionID),
-					zap.Int64("group_offset", partition.Value.Offset))
-
-				topicMark, exists := marks[topicName]
-				if !exists {
-					childLogger.Warn("consumer group has committed offsets on a topic we don't have watermarks for")
-					break // We can stop trying to find any other offsets for that topic so let's quit this loop
-				}
-				partitionMark, exists := topicMark[partitionID]
-				if !exists {
-					childLogger.Warn("consumer group has committed offsets on a partition we don't have watermarks for")
-					continue
-				}
-				lag := float64(partitionMark.HighWaterMark - partition.Value.Offset)
-				// Lag might be negative because we fetch group offsets after we get partition offsets. It's kinda a
-				// race condition. Negative lags obviously do not make sense so use at least 0 as lag.
-				lag = math.Max(0, lag)
-				topicLag += lag
-				topicOffsetSum += float64(partition.Value.Offset)
-
-				// Offset commit count for this consumer group
-				offsetCommits += partition.CommitCount
-
-				if e.minionSvc.Cfg.ConsumerGroups.Granularity == minion.ConsumerGroupGranularityTopic {
-					continue
-				}
-				ch <- prometheus.MustNewConstMetric(
-					e.consumerGroupTopicPartitionLag,
-					prometheus.GaugeValue,
-					lag,
-					groupName,
-					topicName,
-					strconv.Itoa(int(partitionID)),
-				)
+			topicMark, exists := marks[topicName]
+			if !exists {
+				e.logger.Warn("consumer group has committed offsets on a topic we don't have watermarks for",
+					zap.String("consumer_group", groupName), zap.String("topic_name", topicName))
+				continue
 			}
-			ch <- prometheus.MustNewConstMetric(
-				e.consumerGroupTopicLag,
-				prometheus.GaugeValue,
-				topicLag,
-				groupName,
-				topicName,
-			)
-			ch <- prometheus.MustNewConstMetric(
-				e.consumerGroupTopicOffsetSum,
-				prometheus.GaugeValue,
-				topicOffsetSum,
-				groupName,
-				topicName,
-			)
+			offsetsForTopic := make([]partitionOffsetLag, 0, len(topic))
+			for partitionID, partition := range topic {
+				offsetsForTopic = append(offsetsForTopic, partitionOffsetLag{
+					PartitionID: partitionID,
+					GroupOffset: partition.Value.Offset,
+					CommitCount: partition.CommitCount,
+				})
+			}
+			offsetCommits += e.emitTopicLag(ch, groupName, topicName, offsetsForTopic, topicMark, e.minionSvc.Cfg.ConsumerGroups.Granularity)
 		}
 
 		ch <- prometheus.MustNewConstMetric(
@@ -126,7 +128,6 @@ func (e *Exporter) collectConsumerGroupLagsAdminAPI(ctx context.Context, ch chan
 
 	groupOffsets, _ := e.minionSvc.ListAllConsumerGroupOffsetsAdminAPI(ctx)
 	for groupName, offsetRes := range groupOffsets {
-
 		err := kerr.ErrorForCode(offsetRes.ErrorCode)
 		if err != nil {
 			e.logger.Warn("failed to get offsets from consumer group, inner kafka error",
@@ -136,69 +137,28 @@ func (e *Exporter) collectConsumerGroupLagsAdminAPI(ctx context.Context, ch chan
 			continue
 		}
 		for _, topic := range offsetRes.Topics {
-			topicLag := float64(0)
-			topicOffsetSum := float64(0)
+			topicMark, exists := marks[topic.Topic]
+			if !exists {
+				e.logger.Warn("consumer group has committed offsets on a topic we don't have watermarks for",
+					zap.String("consumer_group", groupName), zap.String("topic_name", topic.Topic))
+				isOk = false
+				continue
+			}
+			offsetsForTopic := make([]partitionOffsetLag, 0, len(topic.Partitions))
 			for _, partition := range topic.Partitions {
-				err := kerr.ErrorForCode(partition.ErrorCode)
-				if err != nil {
+				if perr := kerr.ErrorForCode(partition.ErrorCode); perr != nil {
 					e.logger.Warn("failed to get consumer group offsets for a partition, inner kafka error",
 						zap.String("consumer_group", groupName),
-						zap.Error(err))
+						zap.Error(perr))
 					isOk = false
 					continue
 				}
-
-				childLogger := e.logger.With(
-					zap.String("consumer_group", groupName),
-					zap.String("topic_name", topic.Topic),
-					zap.Int32("partition_id", partition.Partition),
-					zap.Int64("group_offset", partition.Offset))
-				topicMark, exists := marks[topic.Topic]
-				if !exists {
-					childLogger.Warn("consumer group has committed offsets on a topic we don't have watermarks for")
-					isOk = false
-					break // We can stop trying to find any other offsets for that topic so let's quit this loop
-				}
-				partitionMark, exists := topicMark[partition.Partition]
-				if !exists {
-					childLogger.Warn("consumer group has committed offsets on a partition we don't have watermarks for")
-					isOk = false
-					continue
-				}
-				lag := float64(partitionMark.HighWaterMark - partition.Offset)
-				// Lag might be negative because we fetch group offsets after we get partition offsets. It's kinda a
-				// race condition. Negative lags obviously do not make sense so use at least 0 as lag.
-				lag = math.Max(0, lag)
-				topicLag += lag
-				topicOffsetSum += float64(partition.Offset)
-
-				if e.minionSvc.Cfg.ConsumerGroups.Granularity == minion.ConsumerGroupGranularityTopic {
-					continue
-				}
-				ch <- prometheus.MustNewConstMetric(
-					e.consumerGroupTopicPartitionLag,
-					prometheus.GaugeValue,
-					lag,
-					groupName,
-					topic.Topic,
-					strconv.Itoa(int(partition.Partition)),
-				)
+				offsetsForTopic = append(offsetsForTopic, partitionOffsetLag{
+					PartitionID: partition.Partition,
+					GroupOffset: partition.Offset,
+				})
 			}
-
-			ch <- prometheus.MustNewConstMetric(
-				e.consumerGroupTopicLag,
-				prometheus.GaugeValue,
-				topicLag,
-				groupName,
-				topic.Topic,
-			)
-			ch <- prometheus.MustNewConstMetric(
-				e.consumerGroupTopicOffsetSum,
-				prometheus.GaugeValue,
-				topicOffsetSum,
-				groupName,
-				topic.Topic,
-			)
+			e.emitTopicLag(ch, groupName, topic.Topic, offsetsForTopic, topicMark, e.minionSvc.Cfg.ConsumerGroups.Granularity)
 		}
 	}
 	return isOk

--- a/prometheus/collect_consumer_group_lags_test.go
+++ b/prometheus/collect_consumer_group_lags_test.go
@@ -1,0 +1,82 @@
+package prometheus
+
+import (
+	"testing"
+
+	"github.com/cloudhut/kminion/v2/minion"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func newTestExporterForLagTests() *Exporter {
+	return &Exporter{
+		logger:                         zap.NewNop(),
+		consumerGroupTopicPartitionLag: prometheus.NewDesc("test_partition_lag", "help", []string{"group_id", "topic_name", "partition_id"}, nil),
+		consumerGroupTopicLag:          prometheus.NewDesc("test_topic_lag", "help", []string{"group_id", "topic_name"}, nil),
+		consumerGroupTopicOffsetSum:    prometheus.NewDesc("test_topic_offset_sum", "help", []string{"group_id", "topic_name"}, nil),
+	}
+}
+
+func TestExporter_EmitTopicLag(t *testing.T) {
+	e := newTestExporterForLagTests()
+
+	marks := map[int32]waterMark{
+		0: {HighWaterMark: 100},
+		1: {HighWaterMark: 50},
+	}
+	offsets := []partitionOffsetLag{
+		{PartitionID: 0, GroupOffset: 90, CommitCount: 3},
+		{PartitionID: 1, GroupOffset: 60, CommitCount: 2}, // group offset ahead of HWM -> lag must clamp to 0
+	}
+
+	ch := make(chan prometheus.Metric, 10)
+	commitCount := e.emitTopicLag(ch, "my-group", "my-topic", offsets, marks, minion.ConsumerGroupGranularityPartition)
+	close(ch)
+
+	assert.Equal(t, 5, commitCount)
+
+	var metrics []prometheus.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+	require.Len(t, metrics, 4) // 2 partition-lag + topic-lag + topic-offset-sum
+
+	var pb dto.Metric
+	require.NoError(t, metrics[0].Write(&pb))
+	assert.Equal(t, float64(10), pb.GetGauge().GetValue()) // partition 0: 100-90
+
+	require.NoError(t, metrics[1].Write(&pb))
+	assert.Equal(t, float64(0), pb.GetGauge().GetValue()) // partition 1: clamped to 0
+
+	require.NoError(t, metrics[2].Write(&pb))
+	assert.Equal(t, float64(10), pb.GetGauge().GetValue()) // topic lag = 10 + 0
+
+	require.NoError(t, metrics[3].Write(&pb))
+	assert.Equal(t, float64(150), pb.GetGauge().GetValue()) // topic offset sum = 90 + 60
+}
+
+func TestExporter_EmitTopicLag_SkipsUnknownPartitions(t *testing.T) {
+	e := newTestExporterForLagTests()
+
+	marks := map[int32]waterMark{0: {HighWaterMark: 100}}
+	// partition 1 has no watermark -> must be skipped, not counted or emitted
+	offsets := []partitionOffsetLag{
+		{PartitionID: 0, GroupOffset: 90, CommitCount: 1},
+		{PartitionID: 1, GroupOffset: 10, CommitCount: 1},
+	}
+
+	ch := make(chan prometheus.Metric, 10)
+	commitCount := e.emitTopicLag(ch, "g", "t", offsets, marks, minion.ConsumerGroupGranularityPartition)
+	close(ch)
+
+	assert.Equal(t, 1, commitCount, "commit count from the partition with no watermark must not be included")
+
+	var metrics []prometheus.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+	require.Len(t, metrics, 3) // 1 partition-lag (partition 0 only) + topic-lag + topic-offset-sum
+}

--- a/prometheus/collect_consumer_groups.go
+++ b/prometheus/collect_consumer_groups.go
@@ -72,22 +72,24 @@ func (e *Exporter) collectConsumerGroups(ctx context.Context, ch chan<- promethe
 			topicPartitionsAssigned := make(map[string]int)
 			membersWithEmptyAssignment := 0
 			failedAssignmentsDecode := 0
+			var lastAssignmentDecodeErr error
 			for _, member := range group.Members {
 				if len(member.MemberAssignment) == 0 {
 					membersWithEmptyAssignment++
 					continue
 				}
 
-				kassignment, err := decodeMemberAssignments(group.ProtocolType, member)
-				if err != nil {
+				kassignment, decodeErr := decodeMemberAssignments(group.ProtocolType, member)
+				if decodeErr != nil {
 					e.logger.Debug("failed to decode consumer group member assignment, internal kafka error",
-						zap.Error(err),
+						zap.Error(decodeErr),
 						zap.String("group_id", group.Group),
 						zap.String("client_id", member.ClientID),
 						zap.String("member_id", member.MemberID),
 						zap.String("client_host", member.ClientHost),
 					)
 					failedAssignmentsDecode++
+					lastAssignmentDecodeErr = decodeErr
 					continue
 				}
 				if kassignment == nil {
@@ -106,7 +108,7 @@ func (e *Exporter) collectConsumerGroups(ctx context.Context, ch chan<- promethe
 
 			if failedAssignmentsDecode > 0 {
 				e.logger.Error("failed to decode consumer group member assignment, internal kafka error",
-					zap.Error(err),
+					zap.Error(lastAssignmentDecodeErr),
 					zap.String("group_id", group.Group),
 					zap.Int("assignment_decode_failures", failedAssignmentsDecode),
 				)

--- a/prometheus/collect_consumer_groups_test.go
+++ b/prometheus/collect_consumer_groups_test.go
@@ -1,0 +1,21 @@
+package prometheus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+func TestDecodeMemberAssignments_UnknownProtocolType(t *testing.T) {
+	a, err := decodeMemberAssignments("connect", kmsg.DescribeGroupsResponseGroupMember{})
+	require.NoError(t, err)
+	assert.Nil(t, a)
+}
+
+func TestDecodeMemberAssignments_ConsumerProtocolType_InvalidBytes(t *testing.T) {
+	member := kmsg.DescribeGroupsResponseGroupMember{MemberAssignment: []byte{0xFF, 0xFF}}
+	_, err := decodeMemberAssignments("consumer", member)
+	assert.Error(t, err)
+}

--- a/prometheus/collect_log_dirs.go
+++ b/prometheus/collect_log_dirs.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (e *Exporter) collectLogDirs(ctx context.Context, ch chan<- prometheus.Metric) bool {
-	if !e.minionSvc.Cfg.LogDirs.Enabled {
+	if !e.minionSvc.IsLogDirsEnabled() {
 		return true
 	}
 	isOk := true

--- a/prometheus/config.go
+++ b/prometheus/config.go
@@ -1,5 +1,7 @@
 package prometheus
 
+import "fmt"
+
 type Config struct {
 	Host      string `koanf:"host"`
 	Port      int    `koanf:"port"`
@@ -9,4 +11,11 @@ type Config struct {
 func (c *Config) SetDefaults() {
 	c.Port = 8080
 	c.Namespace = "kminion"
+}
+
+func (c *Config) Validate() error {
+	if c.Port < 1 || c.Port > 65535 {
+		return fmt.Errorf("exporter.port must be between 1 and 65535, got %d", c.Port)
+	}
+	return nil
 }

--- a/prometheus/config_test.go
+++ b/prometheus/config_test.go
@@ -1,0 +1,28 @@
+package prometheus
+
+import "testing"
+import "github.com/stretchr/testify/assert"
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		port    int
+		wantErr bool
+	}{
+		{"valid port", 8080, false},
+		{"zero port invalid", 0, true},
+		{"negative port invalid", -1, true},
+		{"port above max invalid", 70000, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{Port: tt.port}
+			err := cfg.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes correctness, security, and reliability issues in the `kafka`, `minion`, and `prometheus` packages, found during a multi-persona code review of this repo. This is one of three parallel PRs from that review — the other two cover `e2e` package reliability fixes and Helm chart/Dockerfile hardening.

**Notable fix:** `kafka/client_config_helper.go` had `case "USER_AUTH:"` — a stray trailing colon that meant a configured `authType: USER_AUTH` never matched, silently breaking GSSAPI's `USER_AUTH` authentication mode entirely. This was previously undiscovered and is fixed here alongside adding proper `SASLGSSAPIConfig.Validate()`.

### Commits

- `fix(minion): count all groups before filtering for AllGroupsCount metric` — the `kafka_consumer_group_info_count` metric was reporting the filtered count, not the true cluster-wide total.
- `fix(main): handle SIGTERM so graceful shutdown runs under Kubernetes` — only SIGINT was registered; Kubernetes sends SIGTERM on every pod termination.
- `fix(main): add ReadHeaderTimeout to the metrics HTTP server` — a slow/stalled client on `/metrics` or `/ready` could hold a goroutine and fd open indefinitely.
- `chore(deps): drop github.com/pkg/errors, the last usage was inconsistent with the rest of the repo` — the only remaining usage, mixed with stdlib `%w` wrapping in the same file.
- `fix(minion): stop ignoring context cancellation in checkIfConsumerLagIsCaughtUp` — the loop used unconditional sleeps and ignored ctx cancellation on request errors, causing warnings to log after shutdown began.
- `fix(minion): bound concurrent consumer-group offset requests to avoid a thundering herd` — unbounded per-group goroutines could spike to thousands of concurrent Kafka requests on large clusters.
- `refactor(prometheus): unify duplicated lag-aggregation logic between scrape modes` — de-duplicates the AdminAPI and offsets-topic lag collectors into a shared `emitTopicLag` helper, and stops emitting a misleading `0` lag when a topic has no known watermarks.
- `fix(kafka): add a timeout to the generic OAuth token-fetch HTTP client` — a stalled token endpoint could block the SASL auth callback indefinitely.
- `fix(kafka): add GSSAPI config validation and fix USER_AUTH typo that broke that auth mode` — see notable fix above.
- `fix(minion): track log-dirs support as a synchronized field instead of mutating Cfg` — `ensureCompatibility()` mutated the exported `Cfg` struct with no lock while another package read it directly.
- `refactor(kafka): extract GSSAPI mechanism construction into a testable function` — pulls the GSSAPI branch out of the ~220-line `NewKgoConfig` into an independently-testable `buildGSSAPIMechanism`.
- `fix(minion): correct premature-ready edge case and cache-eviction race` — a never-consumed partition could be misread as caught-up, and a cache key reset could still be evicted early by the original timer.
- `fix(prometheus): log the actual decode error in the aggregate log, not a stale nil` — the aggregate log always logged the group-level `err` (always `nil` at that point) instead of the real per-member decode error.
- `fix(kafka): fail fast on unsupported PKCS#8 keys, enforce https OAuth endpoints, warn on insecure TLS, avoid holding lock during IMS refresh` — a 4-part hardening bundle: PKCS#8 encrypted keys now fail with a clear, actionable error instead of a silent always-fails decrypt; OAuth token endpoints must use `https`; a warning is logged when `insecureSkipTlsVerify` is enabled; the Adobe IMS token-refresh lock is no longer held across network I/O.
- `fix(logging): remove literal %w from zap log message in main.go` — zap doesn't printf-format its message argument, so this was logging literal `%w` characters.
- `fix(config): add exporter port validation and promote consumer group enums to named types` — adds `prometheus.Config.Validate()` (the only config struct missing one) and promotes `ScrapeMode`/`Granularity` from bare strings to named types for compile-time safety.
- `test(minion): add regression coverage for storage lifecycle` — adds tests for `minion/storage.go`'s offset add/delete/ready-state behavior, previously untested.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -race` passes across all packages (`e2e`, `kafka`, `minion`, `prometheus`)
- [ ] Manual live-cluster verification skipped for tasks requiring a real Kafka connection (SIGTERM graceful shutdown under `docker-compose`, consumer-group offset concurrency under load, `checkIfConsumerLagIsCaughtUp` cancellation) — no live cluster available in this environment; verified via code review and unit tests of the extracted pure-logic helpers instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)