### PR TITLE
fix(e2e): resolve data races, panics, and reliability bugs in e2e monitoring

### DIFF
--- a/e2e/client_hooks.go
+++ b/e2e/client_hooks.go
@@ -14,8 +14,7 @@ import (
 type clientHooks struct {
 	logger *zap.Logger
 
-	lastCoordinatorUpdate time.Time
-	currentCoordinator    *atomic.Value // kgo.BrokerMetadata
+	currentCoordinator *atomic.Value // kgo.BrokerMetadata
 }
 
 func newEndToEndClientHooks(logger *zap.Logger) *clientHooks {
@@ -83,6 +82,5 @@ func (c *clientHooks) OnBrokerRead(meta kgo.BrokerMetadata, key int16, bytesRead
 
 	if err == nil {
 		c.currentCoordinator.Store(meta)
-		c.lastCoordinatorUpdate = time.Now()
 	}
 }

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -37,11 +37,6 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("failed to validate topicManagement config: %w", err)
 	}
 
-	_, err = time.ParseDuration(c.ProbeInterval.String())
-	if err != nil {
-		return fmt.Errorf("failed to parse '%s' to time.Duration: %v", c.ProbeInterval.String(), err)
-	}
-
 	err = c.Producer.Validate()
 	if err != nil {
 		return fmt.Errorf("failed to validate producer config: %w", err)

--- a/e2e/config_producer.go
+++ b/e2e/config_producer.go
@@ -18,7 +18,7 @@ func (c *EndToEndProducerConfig) SetDefaults() {
 func (c *EndToEndProducerConfig) Validate() error {
 
 	if c.RequiredAcks != "all" && c.RequiredAcks != "leader" {
-		return fmt.Errorf("producer.requiredAcks must be 'all' or 'leader")
+		return fmt.Errorf("producer.requiredAcks must be 'all' or 'leader'")
 	}
 
 	if c.AckSla <= 0 {

--- a/e2e/config_producer_test.go
+++ b/e2e/config_producer_test.go
@@ -1,0 +1,16 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndToEndProducerConfig_Validate_ErrorMessageIsWellFormed(t *testing.T) {
+	cfg := EndToEndProducerConfig{RequiredAcks: "bogus", AckSla: time.Second}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Equal(t, "producer.requiredAcks must be 'all' or 'leader'", err.Error())
+}

--- a/e2e/config_topic.go
+++ b/e2e/config_topic.go
@@ -31,11 +31,11 @@ func (c *EndToEndTopicConfig) SetDefaults() {
 func (c *EndToEndTopicConfig) Validate() error {
 
 	if c.ReplicationFactor < 1 {
-		return fmt.Errorf("failed to parse replicationFactor, it should be more than 1, retrieved value %v", c.ReplicationFactor)
+		return fmt.Errorf("failed to parse replicationFactor, it should be at least 1, retrieved value %v", c.ReplicationFactor)
 	}
 
 	if c.PartitionsPerBroker < 1 {
-		return fmt.Errorf("failed to parse partitionsPerBroker, it should be more than 1, retrieved value %v", c.PartitionsPerBroker)
+		return fmt.Errorf("failed to parse partitionsPerBroker, it should be at least 1, retrieved value %v", c.PartitionsPerBroker)
 	}
 
 	// If the timeduration is 0s or 0ms or its variation of zero, it will be parsed as 0

--- a/e2e/config_topic_test.go
+++ b/e2e/config_topic_test.go
@@ -177,3 +177,11 @@ func TestPartitionPlanner_RebalancePartitionsDisabled_Creates(t *testing.T) {
 	assert.NotEqual(t, int32(0), newLeader,
 		"new partition should not be led by broker 0 (already leads 3 partitions in actual state)")
 }
+
+func TestEndToEndTopicConfig_Validate_ErrorMessageWording(t *testing.T) {
+	cfg := EndToEndTopicConfig{ReplicationFactor: 0, PartitionsPerBroker: 1, ReconciliationInterval: time.Minute}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least 1")
+	assert.NotContains(t, err.Error(), "more than 1")
+}

--- a/e2e/consumer.go
+++ b/e2e/consumer.go
@@ -33,6 +33,11 @@ func (s *Service) startConsumeMessages(ctx context.Context, initializedCh chan<-
 	isInitialized := false
 	for {
 		fetches := client.PollFetches(ctx)
+		if ctx.Err() != nil {
+			// Context was cancelled (e.g. kminion is shutting down); PollFetches returns immediately
+			// in this case, so stop here instead of busy-spinning and logging the same error forever.
+			return
+		}
 		if !isInitialized {
 			isInitialized = true
 			initializedCh <- true

--- a/e2e/consumer.go
+++ b/e2e/consumer.go
@@ -11,6 +11,18 @@ import (
 	"go.uber.org/zap"
 )
 
+// coordinatorIDFromAtomicValue safely extracts the coordinator broker ID from the value stored in
+// clientHooks.currentCoordinator. ok=false means no coordinator has been observed yet (e.g. before
+// the first successful JoinGroup/Heartbeat/SyncGroup/OffsetCommit response) -- callers must not
+// treat that as a panic-worthy condition.
+func coordinatorIDFromAtomicValue(v interface{}) (id string, ok bool) {
+	coordinator, ok := v.(kgo.BrokerMetadata)
+	if !ok {
+		return "", false
+	}
+	return strconv.Itoa(int(coordinator.NodeID)), true
+}
+
 func (s *Service) startConsumeMessages(ctx context.Context, initializedCh chan<- bool) {
 	client := s.client
 
@@ -53,8 +65,11 @@ func (s *Service) commitOffsets(ctx context.Context) {
 	client.CommitOffsets(childCtx, uncommittedOffset, func(_ *kgo.Client, req *kmsg.OffsetCommitRequest, r *kmsg.OffsetCommitResponse, err error) {
 		cancel()
 
-		coordinator := s.clientHooks.currentCoordinator.Load().(kgo.BrokerMetadata)
-		coordinatorID := strconv.Itoa(int(coordinator.NodeID))
+		coordinatorID, ok := coordinatorIDFromAtomicValue(s.clientHooks.currentCoordinator.Load())
+		if !ok {
+			s.logger.Warn("skipping offset commit metrics: no consumer group coordinator has been observed yet")
+			return
+		}
 
 		latency := time.Since(startCommitTimestamp)
 		s.offsetCommitLatency.WithLabelValues(coordinatorID).Observe(latency.Seconds())

--- a/e2e/consumer_test.go
+++ b/e2e/consumer_test.go
@@ -1,0 +1,22 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func TestCoordinatorIDFromAtomicValue(t *testing.T) {
+	t.Run("nil value (no coordinator observed yet) returns ok=false instead of panicking", func(t *testing.T) {
+		id, ok := coordinatorIDFromAtomicValue(nil)
+		assert.False(t, ok)
+		assert.Empty(t, id)
+	})
+
+	t.Run("valid BrokerMetadata returns its NodeID as a string", func(t *testing.T) {
+		id, ok := coordinatorIDFromAtomicValue(kgo.BrokerMetadata{NodeID: 7})
+		assert.True(t, ok)
+		assert.Equal(t, "7", id)
+	})
+}

--- a/e2e/endtoend_message.go
+++ b/e2e/endtoend_message.go
@@ -1,6 +1,9 @@
 package e2e
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 const (
 	_ = iota
@@ -14,11 +17,35 @@ type EndToEndMessage struct {
 	Timestamp int64  `json:"createdUtcNs"` // when the message was created, unix nanoseconds
 
 	// The following properties are only used within the message tracker
-	partition      int
+	partition int
+
+	// mu guards state and produceLatency: they are written by the produce-ack callback goroutine
+	// and read by the message tracker's onMessageExpired eviction goroutine.
+	mu             sync.RWMutex
 	state          int
 	produceLatency float64
 }
 
 func (m *EndToEndMessage) creationTime() time.Time {
 	return time.Unix(0, m.Timestamp)
+}
+
+// markProducedSuccessfully records that the message was successfully produced along with its ack latency.
+func (m *EndToEndMessage) markProducedSuccessfully(latencySeconds float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.state = EndToEndMessageStateProducedSuccessfully
+	m.produceLatency = latencySeconds
+}
+
+func (m *EndToEndMessage) getState() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.state
+}
+
+func (m *EndToEndMessage) getProduceLatency() float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.produceLatency
 }

--- a/e2e/endtoend_message_test.go
+++ b/e2e/endtoend_message_test.go
@@ -1,0 +1,37 @@
+package e2e
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEndToEndMessage_MarkProducedSuccessfully(t *testing.T) {
+	msg := &EndToEndMessage{state: EndToEndMessageStateCreated}
+
+	msg.markProducedSuccessfully(1.5)
+
+	assert.Equal(t, EndToEndMessageStateProducedSuccessfully, msg.getState())
+	assert.Equal(t, 1.5, msg.getProduceLatency())
+}
+
+func TestEndToEndMessage_ConcurrentAccessNoRace(t *testing.T) {
+	msg := &EndToEndMessage{state: EndToEndMessageStateCreated}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		msg.markProducedSuccessfully(0.25)
+	}()
+
+	go func() {
+		defer wg.Done()
+		_ = msg.getState()
+		_ = msg.getProduceLatency()
+	}()
+
+	wg.Wait()
+}

--- a/e2e/group_tracker.go
+++ b/e2e/group_tracker.go
@@ -60,7 +60,7 @@ func (g *groupTracker) start(ctx context.Context) {
 			childCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 			err := g.checkAndDeleteOldConsumerGroups(childCtx)
 			if err != nil {
-				g.logger.Error("failed to check for old consumer groups: %w", zap.Error(err))
+				g.logger.Error("failed to check for old consumer groups", zap.Error(err))
 			}
 			cancel()
 		}

--- a/e2e/group_tracker.go
+++ b/e2e/group_tracker.go
@@ -27,6 +27,7 @@ type groupTracker struct {
 	client                 *kgo.Client          // kafka client
 	groupId                string               // our own groupId
 	potentiallyEmptyGroups map[string]time.Time // groupName -> utc timestamp when the group was first seen
+	deletionDisabled       bool                 // set once a delete attempt returns GroupAuthorizationFailed
 }
 
 func newGroupTracker(cfg Config, logger *zap.Logger, client *kgo.Client, groupID string) *groupTracker {
@@ -37,6 +38,13 @@ func newGroupTracker(cfg Config, logger *zap.Logger, client *kgo.Client, groupID
 		groupId:                groupID,
 		potentiallyEmptyGroups: make(map[string]time.Time),
 	}
+}
+
+// shouldAttemptGroupDeletion reports whether checkAndDeleteOldConsumerGroups should attempt to
+// delete groupsToDelete, given whether deletion was previously disabled due to an authorization
+// failure.
+func shouldAttemptGroupDeletion(deletionDisabled bool, groupsToDelete []string) bool {
+	return !deletionDisabled && len(groupsToDelete) > 0
 }
 
 func (g *groupTracker) start(ctx context.Context) {
@@ -127,7 +135,11 @@ func (g *groupTracker) checkAndDeleteOldConsumerGroups(ctx context.Context) erro
 	}
 
 	// actually delete the groups we've decided to delete
-	if len(groupsToDelete) == 0 {
+	if !shouldAttemptGroupDeletion(g.deletionDisabled, groupsToDelete) {
+		if g.deletionDisabled && len(groupsToDelete) > 0 {
+			g.logger.Debug("skipping deletion of old consumer groups because a previous attempt was not authorized",
+				zap.Int("groups_pending_deletion", len(groupsToDelete)))
+		}
 		return nil
 	}
 
@@ -168,6 +180,7 @@ func (g *groupTracker) checkAndDeleteOldConsumerGroups(ctx context.Context) erro
 	g.logger.Info("deleted old consumer groups", zap.Strings("deleted_groups", deletedGroups))
 
 	if foundNotAuthorizedError {
+		g.deletionDisabled = true
 		g.logger.Info("disabling trying to delete old kminion consumer-groups since one of the last delete results had an 'GroupAuthorizationFailed' error")
 	}
 

--- a/e2e/group_tracker_test.go
+++ b/e2e/group_tracker_test.go
@@ -1,0 +1,14 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldAttemptGroupDeletion(t *testing.T) {
+	assert.True(t, shouldAttemptGroupDeletion(false, []string{"g1"}))
+	assert.False(t, shouldAttemptGroupDeletion(true, []string{"g1"}),
+		"must not retry deletion once disabled by a prior authorization failure")
+	assert.False(t, shouldAttemptGroupDeletion(false, nil), "nothing to delete")
+}

--- a/e2e/message_tracker.go
+++ b/e2e/message_tracker.go
@@ -133,7 +133,7 @@ func (t *messageTracker) onMessageExpired(key string, reason ttlcache.EvictionRe
 		zap.Int64("age_ms", age.Milliseconds()),
 		zap.Int("partition", msg.partition),
 		zap.String("message_id", msg.MessageID),
-		zap.Bool("successfully_produced", msg.state == EndToEndMessageStateProducedSuccessfully),
-		zap.Float64("produce_latency_seconds", msg.produceLatency),
+		zap.Bool("successfully_produced", msg.getState() == EndToEndMessageStateProducedSuccessfully),
+		zap.Float64("produce_latency_seconds", msg.getProduceLatency()),
 	)
 }

--- a/e2e/message_tracker.go
+++ b/e2e/message_tracker.go
@@ -97,10 +97,10 @@ func (t *messageTracker) onMessageArrived(arrivedMessage *EndToEndMessage) {
 	msg := item.Value()
 
 	expireTime := msg.creationTime().Add(t.svc.config.Consumer.RoundtripSla)
-	isExpired := time.Now().Before(expireTime)
+	arrivedInTime := time.Now().Before(expireTime)
 	latency := time.Since(msg.creationTime())
 
-	if !isExpired {
+	if !arrivedInTime {
 		// Message arrived late, but was still in cache. We don't increment the lost counter here because eventually
 		// it will be evicted from the cache. This case should only pop up if the sla time is exceeded, but if the
 		// item has not been evicted from the cache yet.

--- a/e2e/message_tracker_test.go
+++ b/e2e/message_tracker_test.go
@@ -1,0 +1,69 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func newTestServiceForMessageTracker(roundtripSla time.Duration) *Service {
+	return &Service{
+		config:           Config{Consumer: EndToEndConsumerConfig{RoundtripSla: roundtripSla}},
+		logger:           zap.NewNop(),
+		messagesReceived: prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_messages_received"}, []string{"partition_id"}),
+		roundtripLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "test_roundtrip_latency"}, []string{"partition_id"}),
+		lostMessages:     prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_lost_messages"}, []string{"partition_id"}),
+	}
+}
+
+func TestMessageTracker_OnMessageArrived_WithinSLA_RemovesFromCache(t *testing.T) {
+	svc := newTestServiceForMessageTracker(100 * time.Millisecond)
+	tracker := newMessageTracker(svc)
+
+	msg := &EndToEndMessage{MessageID: "m1", Timestamp: time.Now().UnixNano(), partition: 0}
+	tracker.addToTracker(msg)
+
+	tracker.onMessageArrived(&EndToEndMessage{MessageID: "m1", Timestamp: msg.Timestamp, partition: 0})
+
+	assert.Nil(t, tracker.cache.Get("m1"), "an on-time arrival should be removed from the cache")
+}
+
+func TestMessageTracker_OnMessageArrived_TooLate_LeftInCache(t *testing.T) {
+	svc := newTestServiceForMessageTracker(50 * time.Millisecond)
+	tracker := newMessageTracker(svc)
+
+	// A message "created" well before the SLA window relative to now.
+	staleTimestamp := time.Now().Add(-200 * time.Millisecond).UnixNano()
+	msg := &EndToEndMessage{MessageID: "m2", Timestamp: staleTimestamp, partition: 0}
+	tracker.addToTracker(msg)
+
+	tracker.onMessageArrived(&EndToEndMessage{MessageID: "m2", Timestamp: staleTimestamp, partition: 0})
+
+	// A late arrival must be left in the cache for the cache's own TTL eviction to count as lost --
+	// regression test for the arrivedInTime/isExpired naming trap (Task 27): if that boolean's
+	// polarity were ever flipped again, this message would be incorrectly removed here.
+	assert.NotNil(t, tracker.cache.Get("m2"), "a late-arriving message must not be treated as on-time")
+}
+
+func TestMessageTracker_OnMessageExpired_DeletedReason_NoOp(t *testing.T) {
+	svc := newTestServiceForMessageTracker(100 * time.Millisecond)
+	tracker := newMessageTracker(svc)
+
+	tracker.onMessageExpired("m3", ttlcache.EvictionReasonDeleted, &EndToEndMessage{MessageID: "m3", Timestamp: time.Now().UnixNano(), partition: 0})
+
+	assert.Equal(t, float64(0), testutil.ToFloat64(svc.lostMessages.WithLabelValues("0")))
+}
+
+func TestMessageTracker_OnMessageExpired_TimeoutReason_IncrementsLostMessages(t *testing.T) {
+	svc := newTestServiceForMessageTracker(100 * time.Millisecond)
+	tracker := newMessageTracker(svc)
+
+	tracker.onMessageExpired("m4", ttlcache.EvictionReasonExpired, &EndToEndMessage{MessageID: "m4", Timestamp: time.Now().UnixNano(), partition: 2})
+
+	assert.Equal(t, float64(1), testutil.ToFloat64(svc.lostMessages.WithLabelValues("2")))
+}

--- a/e2e/producer.go
+++ b/e2e/producer.go
@@ -58,8 +58,7 @@ func (s *Service) produceMessage(ctx context.Context, partition int) {
 			// produced successfully, but it got lost somewhere.
 			// We need to use updateItemIfExists() because it's possible that the message has already been consumed
 			// before we have received the message here (because we were awaiting the produce ack).
-			msg.state = EndToEndMessageStateProducedSuccessfully
-			msg.produceLatency = ackDuration.Seconds()
+			msg.markProducedSuccessfully(ackDuration.Seconds())
 
 			// TODO: Enable again as soon as https://github.com/jellydatora/ttlcache/issues/60 is fixed
 			// Because we cannot update cache items in an atomic fashion we currently can't use this method

--- a/e2e/producer.go
+++ b/e2e/producer.go
@@ -13,7 +13,7 @@ import (
 
 // produceMessagesToAllPartitions sends an EndToEndMessage to every partition on the given topic
 func (s *Service) produceMessagesToAllPartitions(ctx context.Context) {
-	for i := 0; i < s.partitionCount; i++ {
+	for i := 0; i < int(s.partitionCount.Load()); i++ {
 		s.produceMessage(ctx, i)
 	}
 }

--- a/e2e/service.go
+++ b/e2e/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -28,7 +29,7 @@ type Service struct {
 	groupTracker   *groupTracker   // tracks consumer groups starting with the kminion prefix and deletes them if they are unused for some time
 	messageTracker *messageTracker // tracks successfully produced messages,
 	clientHooks    *clientHooks    // logs broker events, tracks the coordinator (i.e. which broker last responded to our offset commit)
-	partitionCount int             // number of partitions of our test topic, used to send messages to all partitions
+	partitionCount atomic.Int32    // number of partitions of our test topic, used to send messages to all partitions
 
 	// Metrics
 	messagesProducedInFlight *prometheus.GaugeVec
@@ -209,7 +210,7 @@ func (s *Service) Start(ctx context.Context) error {
 func (s *Service) sendInitMessage(ctx context.Context, client *kgo.Client, topicName string) {
 	// Try to produce one record into each partition. This is important because
 	// one or more partitions may be offline, while others may still be writable.
-	for i := 0; i < s.partitionCount; i++ {
+	for i := 0; i < int(s.partitionCount.Load()); i++ {
 		client.TryProduce(ctx, &kgo.Record{
 			Key:       []byte("init-message"),
 			Value:     nil,

--- a/e2e/service_test.go
+++ b/e2e/service_test.go
@@ -1,0 +1,28 @@
+package e2e
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestService_PartitionCount_ConcurrentAccessNoRace(t *testing.T) {
+	svc := &Service{}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		svc.partitionCount.Store(6)
+	}()
+
+	go func() {
+		defer wg.Done()
+		_ = svc.partitionCount.Load()
+	}()
+
+	wg.Wait()
+	assert.Equal(t, int32(6), svc.partitionCount.Load())
+}

--- a/e2e/topic.go
+++ b/e2e/topic.go
@@ -166,8 +166,8 @@ func (s *Service) updatePartitionCount(ctx context.Context) error {
 
 			typedErr := kerr.TypedErrorForCode(meta.Topics[0].ErrorCode)
 			if typedErr == nil {
-				s.partitionCount = len(meta.Topics[0].Partitions)
-				s.logger.Debug("updatePartitionCount: successfully updated partition count", zap.Int("partition_count", s.partitionCount))
+				s.partitionCount.Store(int32(len(meta.Topics[0].Partitions)))
+				s.logger.Debug("updatePartitionCount: successfully updated partition count", zap.Int32("partition_count", s.partitionCount.Load()))
 				return nil
 			}
 			if !errors.Is(typedErr, kerr.UnknownTopicOrPartition) {

--- a/e2e/topic.go
+++ b/e2e/topic.go
@@ -12,6 +12,22 @@ import (
 	"go.uber.org/zap"
 )
 
+// topicStatusFromMetadata classifies whether the e2e topic exists based on its metadata error code.
+// unexpectedErr is non-nil only when the topic's metadata reports an error other than
+// UnknownTopicOrPartition -- the caller should treat that as a hard failure.
+func topicStatusFromMetadata(errorCode int16) (exists bool, unexpectedErr error) {
+	typedErr := kerr.TypedErrorForCode(errorCode)
+	switch {
+	case typedErr == nil:
+		return true, nil
+	case errors.Is(typedErr, kerr.UnknownTopicOrPartition):
+		// The topic does not exist yet; the caller will create it.
+		return false, nil
+	default:
+		return false, typedErr
+	}
+}
+
 // Check our end-to-end test topic and adapt accordingly if something does not match our expectations.
 // - does it exist?
 //
@@ -30,18 +46,9 @@ func (s *Service) validateManagementTopic(ctx context.Context) error {
 		return fmt.Errorf("validateManagementTopic cannot get metadata of e2e topic: %w", err)
 	}
 
-	typedErr := kerr.TypedErrorForCode(meta.Topics[0].ErrorCode)
-	topicExists := false
-	switch {
-	case typedErr == nil:
-		topicExists = true
-	case errors.Is(typedErr, kerr.UnknownTopicOrPartition):
-		// UnknownTopicOrPartition (Error code 3) means that the topic does not exist.
-		// When the topic doesn't exist, continue to create it further down in the code.
-		topicExists = false
-	default:
-		// If the topic (possibly) exists, but there's an error, then this should result in a fail
-		return fmt.Errorf("failed to get metadata for end-to-end topic: %w", err)
+	topicExists, unexpectedErr := topicStatusFromMetadata(meta.Topics[0].ErrorCode)
+	if unexpectedErr != nil {
+		return fmt.Errorf("failed to get metadata for end-to-end topic: %w", unexpectedErr)
 	}
 
 	// Create topic if it doesn't exist

--- a/e2e/topic_test.go
+++ b/e2e/topic_test.go
@@ -1,0 +1,30 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kerr"
+)
+
+func TestTopicStatusFromMetadata(t *testing.T) {
+	t.Run("no error means topic exists", func(t *testing.T) {
+		exists, err := topicStatusFromMetadata(0) // 0 == NONE, no error
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("unknown topic or partition means topic does not exist, no error", func(t *testing.T) {
+		exists, err := topicStatusFromMetadata(kerr.UnknownTopicOrPartition.Code)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("other kafka errors are returned as the real typed error, not swallowed as nil", func(t *testing.T) {
+		exists, err := topicStatusFromMetadata(kerr.GroupAuthorizationFailed.Code)
+		require.Error(t, err)
+		assert.False(t, exists)
+		assert.ErrorIs(t, err, kerr.GroupAuthorizationFailed)
+	})
+}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"math"
 	"time"
 
@@ -18,8 +19,11 @@ func createHistogramBuckets(maxLatency time.Duration) []float64 {
 	// Divide by 10 for the argument because the base is counted as 20ms and we want to normalize it as base 2 instead of 20
 	// +2 because it starts at 5ms or 0.005 sec, to account 5ms and 10ms before it goes to the base which in this case is 0.02 sec or 20ms
 	// and another +1 to account for decimal points on int parsing
-	latencyCount := math.Logb(float64(maxLatency.Milliseconds() / 10))
+	latencyCount := math.Logb(float64(maxLatency.Milliseconds()) / 10)
 	count := int(latencyCount) + 3
+	if count < 1 {
+		count = 1
+	}
 	bucket := prometheus.ExponentialBuckets(0.005, 2, count)
 
 	return bucket
@@ -37,7 +41,7 @@ func containsStr(ar []string, x string) (bool, int) {
 // logCommitErrors logs all errors in commit response and returns a well formatted error code if there was one
 func (s *Service) logCommitErrors(r *kmsg.OffsetCommitResponse, err error) string {
 	if err != nil {
-		if err == context.DeadlineExceeded {
+		if errors.Is(err, context.DeadlineExceeded) {
 			s.logger.Warn("offset commit failed because SLA has been exceeded")
 			return "OFFSET_COMMIT_SLA_EXCEEDED"
 		}

--- a/e2e/utils_test.go
+++ b/e2e/utils_test.go
@@ -1,0 +1,22 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateHistogramBuckets_SubTenMillisecondSLA_DoesNotPanic(t *testing.T) {
+	require.NotPanics(t, func() {
+		buckets := createHistogramBuckets(5 * time.Millisecond)
+		assert.NotEmpty(t, buckets)
+	})
+}
+
+func TestCreateHistogramBuckets_NormalSLA(t *testing.T) {
+	buckets := createHistogramBuckets(5 * time.Second)
+	assert.NotEmpty(t, buckets)
+	assert.Equal(t, 0.005, buckets[0])
+}

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect


### PR DESCRIPTION
Resolves data races, panics, and reliability bugs in KMinion's end-to-end monitoring package.

## Commits (each is one reviewable task)

- fix(e2e): guard `EndToEndMessage` state/produceLatency with a mutex to remove data race
- fix(e2e): make `partitionCount` an `atomic.Int32` to remove data race
- fix(e2e): wrap the real typed Kafka error instead of an already-nil `err` in `validateManagementTopic`
- fix(e2e): stop panicking on offset commit when no coordinator has been observed yet (unchecked type assertion)
- fix(e2e): stop busy-spinning on context cancellation in the e2e consume loop
- fix(e2e): actually stop retrying group deletion after an authorization failure (state was logged but never persisted)
- fix(logging): remove literal `%w` from a zap log message in `group_tracker.go` (zap doesn't printf-format messages)
- fix(e2e): fix backwards boolean naming, `errors.Is` comparison, dead field, and a histogram sub-10ms panic guard
- fix(e2e): fix config validation message wording and remove dead validation round-trip
- test(e2e): add regression coverage for message tracker lifecycle

## Verification

`go build ./...`, `go vet ./...`, and `go test ./... -race` all pass. The two data-race fixes were verified under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
