### PR TITLE
fix(chart,docker): harden Helm chart, Docker image, and release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -61,6 +62,7 @@ jobs:
           labels: |
             org.opencontainers.image.description=KMinion - Prometheus Exporter for Apache Kafka
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -73,6 +75,26 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
+      - name: Install cosign
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: sigstore/cosign-installer@v3
+      - name: Sign the image (keyless)
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+        run: |
+          cosign sign --yes "${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+      - name: Generate SBOM
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: anchore/sbom-action@v0
+        with:
+          image: "${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+          format: spdx-json
+          output-file: sbom.spdx.json
+      - name: Attach SBOM to the image
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          cosign attest --yes --predicate sbom.spdx.json --type spdxjson "${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
 
   release-helm:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN CGO_ENABLED=0 go build \
 ############################################################
 # Runtime Image
 ############################################################
-FROM alpine:latest
+FROM alpine:3.21
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/bin/kminion /app/kminion
 RUN chmod -R +x /app/kminion

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/bin/kminion /app/kminion
 RUN chmod -R +x /app/kminion
 
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8080/ready || exit 1
+
 ENTRYPOINT ["/app/kminion"]

--- a/charts/README.md
+++ b/charts/README.md
@@ -10,6 +10,17 @@ you might run into runtime errors for a misconfiguration.
 
 All available input is documented inside of the [values.yaml](./kminion/values.yaml) file.
 
+## Secrets
+
+`kminion.config` is rendered verbatim into a Kubernetes ConfigMap, which is stored unencrypted and readable by
+any principal with `configmap get/list` RBAC in the release namespace. Do not put credentials there — this
+includes `sasl.password`, `sasl.gssapi.password`, `tls.passphrase`, `tls.key`, and OAuth client secrets.
+
+Instead, use `deployment.env.secretKeyRefs` to inject credentials from a Kubernetes Secret as environment
+variables. See the commented example under `deployment.env` in [values.yaml](./kminion/values.yaml), and the
+[reference config](https://github.com/cloudhut/kminion/blob/master/docs/reference-config.yaml) for the
+expected environment variable names.
+
 ## Installing the Helm chart
 
 ```shell

--- a/charts/kminion/templates/deployment.yaml
+++ b/charts/kminion/templates/deployment.yaml
@@ -102,6 +102,15 @@ spec:
               port: {{.Values.service.port}}
             initialDelaySeconds: 10
           {{- end }}
+          {{- if .Values.deployment.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: {{.Values.service.port}}
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 6
+          {{- end }}
         {{- with .Values.deployment.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/kminion/templates/hpa.yaml
+++ b/charts/kminion/templates/hpa.yaml
@@ -28,6 +28,6 @@ spec:
         name: memory
         target:
           type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/charts/kminion/values.yaml
+++ b/charts/kminion/values.yaml
@@ -145,6 +145,8 @@ daemonset:
 deployment:
   readinessProbe:
     enabled: true
+  livenessProbe:
+    enabled: true
 
   labels: {}
   # Annotations to add to the Deployment resource

--- a/charts/kminion/values.yaml
+++ b/charts/kminion/values.yaml
@@ -189,6 +189,12 @@ kminion:
   # KMinion can be configured using environment variables and/or a YAML config. The yaml contents under config will
   # end up in a YAML file which will be mounted into the kminion container.
   # See reference config: https://github.com/cloudhut/kminion/blob/master/docs/reference-config.yaml
+  #
+  # WARNING: anything placed under `config` (including this block's commented example below) is rendered
+  # verbatim into a Kubernetes ConfigMap, which is stored unencrypted and readable by any principal with
+  # configmap get/list RBAC in this namespace. Do NOT put sasl.password, sasl.gssapi.password, tls.passphrase,
+  # tls.key, or oauth client secrets here. Use `deployment.env.secretKeyRefs` below instead, which injects
+  # them from a Kubernetes Secret as environment variables.
   config: {}
 #    kafka:
 #      brokers: [ ]
@@ -207,6 +213,7 @@ kminion:
 #        # Username to use for PLAIN or SCRAM mechanism
 #        username: ""
 #        # Password to use for PLAIN or SCRAM mechanism
+#        # DO NOT set this here -- it lands in a plaintext ConfigMap. Use deployment.env.secretKeyRefs instead.
 #        password: ""
 #        # Mechanism to use for SASL Authentication. Valid values are PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, GSSAPI
 #        mechanism: "PLAIN"
@@ -217,6 +224,7 @@ kminion:
 #          kerberosConfigPath: ""
 #          serviceName: ""
 #          username: ""
+#          # DO NOT set this here -- it lands in a plaintext ConfigMap. Use deployment.env.secretKeyRefs instead.
 #          password: ""
 #          realm: ""
 #      # Whether to retry the initial test connection to Kafka. False will exit with code 1 on error,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,3 +45,9 @@ services:
     environment:
       KAFKA_BROKERS: kafka:29092
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080/ready"]
+      interval: 30s
+      timeout: 3s
+      start_period: 10s
+      retries: 3


### PR DESCRIPTION
Hardens the Helm chart, Docker image, and release pipeline.

## Commits

- fix(chart): HPA memory metric was reading the CPU target percentage (copy-paste bug → memory target silently scaled on CPU)
- fix(chart): add `livenessProbe` to the Deployment, matching the DaemonSet's existing pattern (generous threshold to avoid restart-looping during `/ready` catch-up)
- docs(chart): warn that `kminion.config` renders into a plaintext ConfigMap; point to `deployment.env.secretKeyRefs` for credentials
- fix(docker): pin the runtime base image to `alpine:3.21` instead of `:latest` (reproducible builds)
- fix(docker): add `HEALTHCHECK` for the `docker run` / docker-compose path
- ci(release): sign released images with cosign and attach an SBOM

## Note

Container securityContext / non-root hardening was intentionally **excluded** from this PR (deferred), to avoid coupling the chart's `runAsNonRoot` defaults to an image/tag rollout. The image continues to run as before.

## Verification

`helm lint` clean, `helm template` renders, `docker build` succeeds, image runs as root (unchanged), HEALTHCHECK present, alpine pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
