### PR TITLE
perf(minion): batch consumer-group offset fetches into chunked multi-group OffsetFetch

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -27,6 +27,9 @@ jobs:
       - name: Build KMinion
         run: make build
 
+      - name: Seed consumer groups (exercise batched multi-group OffsetFetch)
+        run: make e2e-seed
+
       - name: Start KMinion with E2E tests
         run: make e2e-start
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build test e2e-setup e2e-start e2e-stop e2e-test e2e-cleanup e2e-full
+.PHONY: help build test e2e-setup e2e-seed e2e-start e2e-stop e2e-test e2e-cleanup e2e-full
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'
@@ -19,6 +19,10 @@ e2e-setup: ## Start Kafka cluster for E2E testing
 	@chmod +x e2e/bin/setup-kafka.sh
 	./e2e/bin/setup-kafka.sh start
 
+e2e-seed: ## Seed extra consumer groups to exercise batched multi-group OffsetFetch (run before e2e-start)
+	@chmod +x e2e/bin/seed-consumer-groups.sh
+	./e2e/bin/seed-consumer-groups.sh
+
 e2e-start: ## Start KMinion with E2E configuration
 	@chmod +x e2e/bin/start-kminion.sh
 	./e2e/bin/start-kminion.sh start
@@ -36,10 +40,11 @@ e2e-cleanup: ## Stop and cleanup Kafka cluster and KMinion
 	./e2e/bin/start-kminion.sh stop || true
 	./e2e/bin/setup-kafka.sh stop || true
 
-e2e-full: e2e-setup ## Run full E2E test suite (setup, build, start, test, cleanup)
+e2e-full: e2e-setup ## Run full E2E test suite (setup, build, seed, start, test, cleanup)
 	@echo "Starting full E2E test suite..."
 	@trap '$(MAKE) e2e-cleanup' EXIT; \
 	$(MAKE) build && \
+	$(MAKE) e2e-seed && \
 	$(MAKE) e2e-start && \
 	$(MAKE) e2e-test
 

--- a/docs/reference-config.yaml
+++ b/docs/reference-config.yaml
@@ -100,6 +100,12 @@ minion:
     # IgnoredGroups are regex strings of group ids that shall be ignored/skipped when exporting metrics. Ignored groups
     # take precedence over allowed groups.
     ignoredGroups: [ ]
+    # MaxGroupsPerOffsetFetch bounds how many consumer groups are packed into a single batched OffsetFetch
+    # request in adminApi scrape mode. franz-go sends one request per group coordinator with no internal
+    # chunking, so on clusters where few brokers coordinate very many groups an unbounded batch would build
+    # one very large request/response on a single broker request-handler thread. Chunking caps that while
+    # still collapsing the per-group fan-out into a small number of requests. Set to 0 to disable chunking.
+    maxGroupsPerOffsetFetch: 250
   topics:
     # Enabled can be set to false in order to disable collecting any topic metrics.
     enabled: true

--- a/e2e/bin/integration-test.sh
+++ b/e2e/bin/integration-test.sh
@@ -5,9 +5,12 @@ set -euo pipefail
 # This script validates KMinion's end-to-end monitoring and built-in metrics
 # Can be run locally or in CI
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 METRICS_URL="${METRICS_URL:-http://localhost:8080/metrics}"
 WAIT_TIMEOUT="${WAIT_TIMEOUT:-60}"
+
+# Must match e2e/bin/seed-consumer-groups.sh
+SEED_GROUP_PREFIX="${SEED_GROUP_PREFIX:-e2e-batch-test-group}"
+SEED_GROUP_COUNT="${SEED_GROUP_COUNT:-5}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -181,7 +184,8 @@ validate_builtin_metrics() {
 
     # Check that we have broker info for at least one broker
     local broker_count
-    broker_count=$(echo "$metrics" | grep "^kminion_kafka_broker_info" | wc -l | tr -d ' ')
+    # `|| true` keeps `set -e` happy when grep matches nothing (the check below handles a 0 count).
+    broker_count=$(echo "$metrics" | grep -c "^kminion_kafka_broker_info" || true)
     if [ "$broker_count" -lt 1 ]; then
         log_error "No broker info metrics found"
         return 1
@@ -190,6 +194,44 @@ validate_builtin_metrics() {
     log_info "✅ Built-in metrics validation passed"
     log_info "   Exporter up: $exporter_up"
     log_info "   Brokers detected: $broker_count"
+    return 0
+}
+
+# Validate the batched multi-group OffsetFetch path.
+#
+# The seed script (seed-consumer-groups.sh) creates SEED_GROUP_COUNT consumer groups with committed
+# offsets before KMinion starts. In adminApi scrape mode, KMinion fetches every group's offsets via
+# a single batched multi-group OffsetFetch request (KIP-709). The offset_sum series is emitted
+# exclusively from that offset-fetch path, so seeing it for each seeded group proves the batched
+# request returned that group and the v8->legacy response conversion worked end-to-end.
+validate_batched_group_metrics() {
+    log_info "Validating batched multi-group OffsetFetch (${SEED_GROUP_COUNT} seeded groups)..."
+
+    local metrics
+    metrics=$(fetch_metrics "$METRICS_URL") || return 1
+
+    local offset_sum_series
+    offset_sum_series=$(echo "$metrics" | grep "^kminion_kafka_consumer_group_topic_offset_sum" || true)
+
+    local missing_groups=()
+    for i in $(seq 1 "$SEED_GROUP_COUNT"); do
+        local group="${SEED_GROUP_PREFIX}-${i}"
+        if ! echo "$offset_sum_series" | grep -q "group_id=\"${group}\""; then
+            missing_groups+=("$group")
+        fi
+    done
+
+    if [ ${#missing_groups[@]} -ne 0 ]; then
+        log_error "Batched OffsetFetch did not report offsets for these seeded groups:"
+        printf '  - %s\n' "${missing_groups[@]}"
+        echo ""
+        log_info "consumer_group_topic_offset_sum series present:"
+        echo "$offset_sum_series" || echo "  (none found)"
+        return 1
+    fi
+
+    log_info "✅ Batched OffsetFetch validation passed"
+    log_info "   All ${SEED_GROUP_COUNT} seeded consumer groups reported offsets via the batched path"
     return 0
 }
 
@@ -234,6 +276,11 @@ main() {
 
     # Run built-in metrics validation
     if ! validate_builtin_metrics; then
+        failed=1
+    fi
+
+    # Run batched multi-group OffsetFetch validation
+    if ! validate_batched_group_metrics; then
         failed=1
     fi
 

--- a/e2e/bin/seed-consumer-groups.sh
+++ b/e2e/bin/seed-consumer-groups.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Seed multiple consumer groups with committed offsets.
+#
+# This gives KMinion's AdminAPI scrape mode more than one consumer group to fetch offsets for, so
+# the E2E test actually exercises the *batched multi-group* OffsetFetch path (KIP-709 / OffsetFetch
+# v8+) rather than just KMinion's own single end-to-end group. Each seeded group's offsets can only
+# surface in KMinion's metrics via the batched fetch + the v8->legacy response conversion, so the
+# integration test asserting these groups are reported is a real end-to-end check of that code.
+#
+# Groups are created with committed offsets without a live consumer by using
+# `kafka-consumer-groups.sh --reset-offsets --execute`, which persists offsets for an inactive group.
+#
+# Must run AFTER Kafka is up but BEFORE KMinion starts, because KMinion caches the consumer-group
+# list for 120s on its first scrape.
+
+CONTAINER_NAME="${CONTAINER_NAME:-broker}"
+KAFKA_PORT="${KAFKA_PORT:-9092}"
+BOOTSTRAP="localhost:${KAFKA_PORT}"
+SEED_TOPIC="${SEED_TOPIC:-kminion-batch-test}"
+SEED_GROUP_PREFIX="${SEED_GROUP_PREFIX:-e2e-batch-test-group}"
+SEED_GROUP_COUNT="${SEED_GROUP_COUNT:-5}"
+SEED_RECORD_COUNT="${SEED_RECORD_COUNT:-30}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+
+kbin() { docker exec "$CONTAINER_NAME" "$@"; }
+
+create_topic() {
+    log_info "Creating seed topic '$SEED_TOPIC' (3 partitions)..."
+    kbin /opt/kafka/bin/kafka-topics.sh --bootstrap-server "$BOOTSTRAP" \
+        --create --if-not-exists --topic "$SEED_TOPIC" \
+        --partitions 3 --replication-factor 1
+}
+
+produce_records() {
+    log_info "Producing $SEED_RECORD_COUNT records to '$SEED_TOPIC' (so committed offsets are non-trivial)..."
+    seq 1 "$SEED_RECORD_COUNT" | docker exec -i "$CONTAINER_NAME" \
+        /opt/kafka/bin/kafka-console-producer.sh --bootstrap-server "$BOOTSTRAP" --topic "$SEED_TOPIC"
+}
+
+seed_groups() {
+    log_info "Seeding $SEED_GROUP_COUNT consumer groups with committed offsets..."
+    for i in $(seq 1 "$SEED_GROUP_COUNT"); do
+        local group="${SEED_GROUP_PREFIX}-${i}"
+        # --reset-offsets --execute commits offsets for an inactive group without a live consumer,
+        # creating it in the Empty state with committed offsets on all partitions of the topic.
+        kbin /opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-server "$BOOTSTRAP" \
+            --group "$group" --topic "$SEED_TOPIC" \
+            --reset-offsets --to-earliest --execute > /dev/null
+        log_info "  seeded group: $group"
+    done
+}
+
+verify_seed() {
+    log_info "Verifying committed offsets for '${SEED_GROUP_PREFIX}-1'..."
+    kbin /opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-server "$BOOTSTRAP" \
+        --group "${SEED_GROUP_PREFIX}-1" --describe || true
+}
+
+main() {
+    log_info "Seeding consumer groups for batched OffsetFetch E2E test"
+    create_topic
+    produce_records
+    seed_groups
+    verify_seed
+    log_info "✅ Seeded $SEED_GROUP_COUNT consumer groups on topic '$SEED_TOPIC'"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    main "$@"
+fi

--- a/minion/config_consumer_group.go
+++ b/minion/config_consumer_group.go
@@ -36,6 +36,15 @@ type ConsumerGroupConfig struct {
 	// Allowed values are: Dead, Empty, Stable, PreparingRebalance, CompletingRebalance
 	// Source: https://github.com/apache/kafka/blob/3.4/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
 	AllowedConsumerGroupStates []string `koanf:"allowedConsumerGroupStates"`
+
+	// MaxGroupsPerOffsetFetch bounds how many consumer groups are packed into a single batched
+	// OffsetFetch request in adminApi scrape mode. franz-go sends one request per group coordinator
+	// containing every group that coordinator owns, with no internal chunking, so on clusters where a
+	// few brokers coordinate very many groups an unbounded batch would build one very large
+	// request/response on a single broker request-handler thread. Chunking caps the size of any single
+	// request/response while still collapsing the per-group fan-out into a small number of requests.
+	// A value <= 0 disables chunking (all of a coordinator's groups are sent in one request).
+	MaxGroupsPerOffsetFetch int `koanf:"maxGroupsPerOffsetFetch"`
 }
 
 func (c *ConsumerGroupConfig) SetDefaults() {
@@ -43,6 +52,7 @@ func (c *ConsumerGroupConfig) SetDefaults() {
 	c.ScrapeMode = ConsumerGroupScrapeModeAdminAPI
 	c.Granularity = ConsumerGroupGranularityPartition
 	c.AllowedGroupIDs = []string{"/.*/"}
+	c.MaxGroupsPerOffsetFetch = 250
 }
 
 func (c *ConsumerGroupConfig) Validate() error {

--- a/minion/consumer_group_offsets.go
+++ b/minion/consumer_group_offsets.go
@@ -3,11 +3,8 @@ package minion
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/twmb/franz-go/pkg/kmsg"
-	"go.uber.org/zap"
-	"golang.org/x/sync/errgroup"
 )
 
 // ListAllConsumerGroupOffsetsInternal returns a map from the in memory storage. The map value is the offset commit
@@ -31,50 +28,84 @@ func (s *Service) ListAllConsumerGroupOffsetsAdminAPI(ctx context.Context) (map[
 	return s.listConsumerGroupOffsetsBulk(ctx, groupIDs)
 }
 
-// listConsumerGroupOffsetsBulk returns a map which has the Consumer group name as key
+// listConsumerGroupOffsetsBulk fetches committed offsets for all given consumer groups using
+// batched multi-group OffsetFetch requests (KIP-709, OffsetFetch v8+, Kafka 3.0+).
+//
+// Groups are chunked at ConsumerGroups.MaxGroupsPerOffsetFetch (the `maxGroupsPerOffsetFetch` config
+// option, default 250) and each chunk is issued as one multi-group request. kgo.Client.Request shards
+// each request by group coordinator and merges the per-coordinator responses, so thousands of consumer
+// groups collapse into a small number of batched requests instead of one request per group. On brokers
+// older than v8, franz-go transparently splits each request back into individual per-group requests, so
+// this remains compatible with older Kafka/Redpanda clusters.
 func (s *Service) listConsumerGroupOffsetsBulk(ctx context.Context, groups []string) (map[string]*kmsg.OffsetFetchResponse, error) {
-	eg, _ := errgroup.WithContext(ctx)
+	res := make(map[string]*kmsg.OffsetFetchResponse, len(groups))
 
-	mutex := sync.Mutex{}
-	res := make(map[string]*kmsg.OffsetFetchResponse)
-
-	f := func(group string) func() error {
-		return func() error {
-			offsets, err := s.listConsumerGroupOffsets(ctx, group)
-			if err != nil {
-				s.logger.Warn("failed to fetch consumer group offsets, inner kafka error",
-					zap.String("consumer_group", group),
-					zap.Error(err))
-				return nil
-			}
-
-			mutex.Lock()
-			res[group] = offsets
-			mutex.Unlock()
-			return nil
+	for _, chunk := range chunkGroups(groups, s.Cfg.ConsumerGroups.MaxGroupsPerOffsetFetch) {
+		req := kmsg.NewPtrOffsetFetchRequest()
+		for _, group := range chunk {
+			reqGroup := kmsg.NewOffsetFetchRequestGroup()
+			reqGroup.Group = group
+			req.Groups = append(req.Groups, reqGroup)
 		}
-	}
 
-	for _, group := range groups {
-		eg.Go(f(group))
-	}
+		kresp, err := s.client.Request(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to request consumer group offsets: %w", err)
+		}
+		resp, ok := kresp.(*kmsg.OffsetFetchResponse)
+		if !ok {
+			return nil, fmt.Errorf("unexpected response type %T for OffsetFetch request", kresp)
+		}
 
-	if err := eg.Wait(); err != nil {
-		return nil, err
+		// Per-group errors are carried on each response group's ErrorCode; the prometheus collector
+		// already inspects OffsetFetchResponse.ErrorCode via kerr.ErrorForCode and skips errored groups.
+		for _, group := range resp.Groups {
+			res[group.Group] = offsetFetchResponseGroupToLegacy(group)
+		}
 	}
 
 	return res, nil
 }
 
-// listConsumerGroupOffsets returns the committed group offsets for a single group
-func (s *Service) listConsumerGroupOffsets(ctx context.Context, group string) (*kmsg.OffsetFetchResponse, error) {
-	req := kmsg.NewOffsetFetchRequest()
-	req.Group = group
-	req.Topics = nil
-	res, err := req.RequestWith(ctx, s.client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to request group offsets for group '%v': %w", group, err)
+// chunkGroups splits groups into consecutive chunks of at most size elements, so that each batched
+// OffsetFetch request carries a bounded number of groups regardless of how groups are distributed
+// across coordinators. A non-positive size returns a single chunk containing all groups.
+func chunkGroups(groups []string, size int) [][]string {
+	if size <= 0 {
+		return [][]string{groups}
 	}
+	chunks := make([][]string, 0, (len(groups)+size-1)/size)
+	for start := 0; start < len(groups); start += size {
+		end := start + size
+		if end > len(groups) {
+			end = len(groups)
+		}
+		chunks = append(chunks, groups[start:end])
+	}
+	return chunks
+}
 
-	return res, nil
+// offsetFetchResponseGroupToLegacy converts a v8+ multi-group OffsetFetch response group into the
+// legacy single-group *kmsg.OffsetFetchResponse shape that the rest of the codebase (and the
+// prometheus collector) consumes. This keeps the batched fetch an internal implementation detail.
+func offsetFetchResponseGroupToLegacy(group kmsg.OffsetFetchResponseGroup) *kmsg.OffsetFetchResponse {
+	resp := kmsg.NewPtrOffsetFetchResponse()
+	resp.ErrorCode = group.ErrorCode
+	resp.Topics = make([]kmsg.OffsetFetchResponseTopic, 0, len(group.Topics))
+	for _, topic := range group.Topics {
+		legacyTopic := kmsg.NewOffsetFetchResponseTopic()
+		legacyTopic.Topic = topic.Topic
+		legacyTopic.Partitions = make([]kmsg.OffsetFetchResponseTopicPartition, 0, len(topic.Partitions))
+		for _, partition := range topic.Partitions {
+			legacyPartition := kmsg.NewOffsetFetchResponseTopicPartition()
+			legacyPartition.Partition = partition.Partition
+			legacyPartition.Offset = partition.Offset
+			legacyPartition.LeaderEpoch = partition.LeaderEpoch
+			legacyPartition.Metadata = partition.Metadata
+			legacyPartition.ErrorCode = partition.ErrorCode
+			legacyTopic.Partitions = append(legacyTopic.Partitions, legacyPartition)
+		}
+		resp.Topics = append(resp.Topics, legacyTopic)
+	}
+	return resp
 }

--- a/minion/consumer_group_offsets_test.go
+++ b/minion/consumer_group_offsets_test.go
@@ -1,0 +1,146 @@
+package minion
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+func TestOffsetFetchResponseGroupToLegacy(t *testing.T) {
+	t.Run("multiple topics and partitions map correctly", func(t *testing.T) {
+		partition0 := kmsg.NewOffsetFetchResponseGroupTopicPartition()
+		partition0.Partition = 0
+		partition0.Offset = 123
+		partition0.LeaderEpoch = 5
+		metadata := "some-metadata"
+		partition0.Metadata = &metadata
+		partition0.ErrorCode = 0
+
+		partition1 := kmsg.NewOffsetFetchResponseGroupTopicPartition()
+		partition1.Partition = 1
+		partition1.Offset = 456
+		partition1.LeaderEpoch = 7
+		partition1.ErrorCode = 3 // e.g. UNKNOWN_TOPIC_OR_PARTITION
+
+		topic := kmsg.NewOffsetFetchResponseGroupTopic()
+		topic.Topic = "my-topic"
+		topic.Partitions = []kmsg.OffsetFetchResponseGroupTopicPartition{partition0, partition1}
+
+		group := kmsg.NewOffsetFetchResponseGroup()
+		group.Group = "my-group"
+		group.Topics = []kmsg.OffsetFetchResponseGroupTopic{topic}
+		group.ErrorCode = 0
+
+		legacy := offsetFetchResponseGroupToLegacy(group)
+
+		require.NotNil(t, legacy)
+		require.Len(t, legacy.Topics, 1)
+		assert.Equal(t, "my-topic", legacy.Topics[0].Topic)
+		require.Len(t, legacy.Topics[0].Partitions, 2)
+
+		p0 := legacy.Topics[0].Partitions[0]
+		assert.Equal(t, int32(0), p0.Partition)
+		assert.Equal(t, int64(123), p0.Offset)
+		assert.Equal(t, int32(5), p0.LeaderEpoch)
+		require.NotNil(t, p0.Metadata)
+		assert.Equal(t, "some-metadata", *p0.Metadata)
+		assert.Equal(t, int16(0), p0.ErrorCode)
+
+		p1 := legacy.Topics[0].Partitions[1]
+		assert.Equal(t, int32(1), p1.Partition)
+		assert.Equal(t, int64(456), p1.Offset)
+		assert.Equal(t, int32(7), p1.LeaderEpoch)
+		assert.Nil(t, p1.Metadata)
+		assert.Equal(t, int16(3), p1.ErrorCode)
+	})
+
+	t.Run("group-level error code is preserved", func(t *testing.T) {
+		group := kmsg.NewOffsetFetchResponseGroup()
+		group.Group = "errored-group"
+		group.ErrorCode = 16 // e.g. NOT_COORDINATOR
+
+		legacy := offsetFetchResponseGroupToLegacy(group)
+
+		require.NotNil(t, legacy)
+		assert.Equal(t, int16(16), legacy.ErrorCode)
+	})
+
+	t.Run("empty group yields empty non-nil topics slice", func(t *testing.T) {
+		group := kmsg.NewOffsetFetchResponseGroup()
+		group.Group = "empty-group"
+
+		legacy := offsetFetchResponseGroupToLegacy(group)
+
+		require.NotNil(t, legacy)
+		require.NotNil(t, legacy.Topics)
+		assert.Empty(t, legacy.Topics)
+	})
+}
+
+func TestChunkGroups(t *testing.T) {
+	mkGroups := func(n int) []string {
+		groups := make([]string, n)
+		for i := range groups {
+			groups[i] = "g" + strconv.Itoa(i)
+		}
+		return groups
+	}
+
+	// flatten reconstructs the original slice from chunks so we can assert no group is lost or duplicated.
+	flatten := func(chunks [][]string) []string {
+		var out []string
+		for _, c := range chunks {
+			out = append(out, c...)
+		}
+		return out
+	}
+
+	t.Run("exact multiple of size", func(t *testing.T) {
+		groups := mkGroups(500)
+		chunks := chunkGroups(groups, 250)
+		require.Len(t, chunks, 2)
+		assert.Len(t, chunks[0], 250)
+		assert.Len(t, chunks[1], 250)
+		assert.Equal(t, groups, flatten(chunks))
+	})
+
+	t.Run("remainder chunk", func(t *testing.T) {
+		groups := mkGroups(2001) // representative of a large fleet
+		chunks := chunkGroups(groups, 250)
+		require.Len(t, chunks, 9) // 8 full chunks of 250 + a remainder of 1
+		for _, c := range chunks[:8] {
+			assert.Len(t, c, 250)
+		}
+		assert.Len(t, chunks[8], 1)
+		assert.Equal(t, groups, flatten(chunks))
+	})
+
+	t.Run("fewer groups than size is a single chunk", func(t *testing.T) {
+		groups := mkGroups(10)
+		chunks := chunkGroups(groups, 250)
+		require.Len(t, chunks, 1)
+		assert.Len(t, chunks[0], 10)
+	})
+
+	t.Run("empty input yields no chunks", func(t *testing.T) {
+		chunks := chunkGroups(nil, 250)
+		assert.Empty(t, chunks)
+	})
+
+	t.Run("non-positive size returns a single chunk", func(t *testing.T) {
+		groups := mkGroups(5)
+		chunks := chunkGroups(groups, 0)
+		require.Len(t, chunks, 1)
+		assert.Equal(t, groups, chunks[0])
+	})
+}
+
+func TestConsumerGroupConfigMaxGroupsPerOffsetFetchDefault(t *testing.T) {
+	var cfg ConsumerGroupConfig
+	cfg.SetDefaults()
+	assert.Equal(t, 250, cfg.MaxGroupsPerOffsetFetch,
+		"maxGroupsPerOffsetFetch should default to 250 when not set in config")
+}


### PR DESCRIPTION
## Summary

Consumer-group offset scraping (`adminApi` mode) previously sent **one `OffsetFetch` request per consumer group**, fanned out concurrently. On clusters with many groups that's a request storm against the coordinators.

This switches to the **batched multi-group `OffsetFetch` API** (KIP-709, OffsetFetch v8, Kafka 3.0+). One request can now carry many groups; franz-go shards it by group coordinator and merges the responses, so **N per-group requests collapse into roughly one request per coordinator broker**.

## Why it's better

- **Far fewer requests.** Thousands of groups → a handful of batched requests instead of one per group.
- **Bounded and configurable.** Groups are chunked per request — default 250, configurable via `minion.consumerGroups.maxGroupsPerOffsetFetch` (set to 0 to disable chunking) — so a single coordinator that owns many groups never receives one oversized request.
- **Backward compatible.** On brokers older than v8, franz-go transparently splits the batch back into per-group requests, so Kafka 0.11+ still works.
- **Non-invasive.** The internal return type is unchanged, so the Prometheus collector is untouched.

## Testing

- Unit tests for the response conversion, group chunking, and the chunk-size default.
- **New e2e test** that seeds multiple consumer groups and asserts KMinion reports each one's offsets — which can only come through the batched path. Verified locally against `apache/kafka:4.1.0`: all seeded groups reported offsets via the batched request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
