### PR TITLE
fix(renovate): correctly block kmsg v2 major bump

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,9 +27,11 @@
       "automerge": false
     },
     {
-      "description": "Skip kmsg v2.0.1 specifically - not usable until kgo/kadm depend on kmsg v2",
-      "matchPackageNames": ["github.com/twmb/franz-go/pkg/kmsg/v2"],
-      "allowedVersions": "!/^v2\\.0\\.1$/"
+      "description": "Skip major bump of kmsg to v2 - not usable until kgo/kadm depend on kmsg v2",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["github.com/twmb/franz-go/pkg/kmsg"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary
- PR #75 proposed bumping `github.com/twmb/franz-go/pkg/kmsg` from `v1.13.1` to `v2.0.1` (a Go major-version import-path bump), even though `renovate.json` already had a rule intended to skip it.
- Root cause: the rule matched `matchPackageNames` on `github.com/twmb/franz-go/pkg/kmsg/v2`, but Renovate's gomod manager keys major-version-path bumps by the **old** import path (`.../kmsg`, no `/v2`) — confirmed by PR #75's own title showing `[github.com/twmb/franz-go/pkg/kmsg] v1.13.1 → v2.0.1`. So the rule never matched anything.
- Replaced the single-version `allowedVersions` allowlist with `matchUpdateTypes: ["major"]` + `enabled: false` on the correct (old) package name, blocking the whole v2 line rather than just `v2.0.1`. This matters because `kmsg/v2` currently has zero adoption in the franz-go ecosystem (kgo/kadm still import kmsg v1, and `v2.0.2` is retracted upstream) — any v2.x bump is equally unusable, not just `v2.0.1`.

## Test plan
- [x] Validated with `renovate-config-validator renovate.json` (passes)
- [ ] Close/rebase PR #75 once this merges so Renovate stops recreating the broken major-bump PR