### PR TITLE
fix(ci): stop SBOM action from failing on release-asset upload

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,6 +91,7 @@ jobs:
           image: "${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
           format: spdx-json
           output-file: sbom.spdx.json
+          upload-release-assets: false
       - name: Attach SBOM to the image
         if: startsWith(github.ref, 'refs/tags/')
         run: |


### PR DESCRIPTION
## Summary
- `release-docker-image` job (run: https://github.com/adobe/kminion/actions/runs/31373472310/job/93407435997) failed at the Generate SBOM step with `Resource not accessible by integration` when `anchore/sbom-action` tried to attach the SBOM to the tag's GitHub Release.
- The action defaults `upload-release-assets` to `true`, but the job only grants `contents: read`, so the release-asset write is rejected.
- Rather than widening the job's token to `contents: write` for the whole job (checkout, build, sign, SBOM all run under it), disable the redundant release-asset upload — the SBOM is already retained as a workflow artifact and as a cosign attestation on the immutable image digest.

## Test plan
- [ ] Push a tag and confirm `release-docker-image` completes without the `Generate SBOM` step failing
- [ ] Confirm `sbom.spdx.json` is still uploaded as a workflow artifact
- [ ] Confirm `cosign verify-attestation --type spdxjson` succeeds against the built image digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)